### PR TITLE
自定义外部图片文件名支持相对路径

### DIFF
--- a/MusicPlayer2/AppearanceSettingDlg.cpp
+++ b/MusicPlayer2/AppearanceSettingDlg.cpp
@@ -460,7 +460,8 @@ void CAppearanceSettingDlg::OnOK()
     for (auto& album_name : m_data.default_album_name)
     {
         // 虽然开头的.\\不是后续识别必须的但是如果发现缺少还是加上
-        if (album_name.find(L'\\') != wstring::npos && album_name.front() != L'\\')    // 这是一个非简写的相对路径
+        // 这是一个非简写的相对路径，绝对路径此处不做处理
+        if (album_name.find(L'\\') != wstring::npos && album_name.front() != L'\\' && !CCommon::IsWindowsPath(album_name))
         {
             // 确保相对路径以".\\"开头
             if (album_name.at(0) == L'.' && album_name.at(1) == L'\\')

--- a/MusicPlayer2/AppearanceSettingDlg.cpp
+++ b/MusicPlayer2/AppearanceSettingDlg.cpp
@@ -460,9 +460,9 @@ void CAppearanceSettingDlg::OnOK()
     for (auto& album_name : m_data.default_album_name)
     {
         // 虽然开头的.\\不是后续识别必须的但是如果发现缺少还是加上
-        if (album_name.find(L'\\') != wstring::npos)    // 这是一个相对路径
+        if (album_name.find(L'\\') != wstring::npos && album_name.front() != L'\\')    // 这是一个非简写的相对路径
         {
-            // 有正常的相对路径开头
+            // 确保相对路径以".\\"开头
             if (album_name.at(0) == L'.' && album_name.at(1) == L'\\')
                 continue;
             album_name = L".\\" + album_name;

--- a/MusicPlayer2/AppearanceSettingDlg.cpp
+++ b/MusicPlayer2/AppearanceSettingDlg.cpp
@@ -455,8 +455,19 @@ void CAppearanceSettingDlg::OnOK()
 
     CString temp;
     GetDlgItemText(IDC_DEFAULT_COVER_NAME_EDIT, temp);
+    temp.Replace(L'/', L'\\');
     CCommon::StringSplit(wstring(temp), L',', m_data.default_album_name);
-
+    for (auto& album_name : m_data.default_album_name)
+    {
+        // 虽然开头的.\\不是后续识别必须的但是如果发现缺少还是加上
+        if (album_name.find(L'\\') != wstring::npos)    // 这是一个相对路径
+        {
+            // 有正常的相对路径开头
+            if (album_name.at(0) == L'.' && album_name.at(1) == L'\\')
+                continue;
+            album_name = L".\\" + album_name;
+        }
+    }
     m_data.ui_refresh_interval = m_ui_refresh_interval_edit.GetValue();
 
     //CTabDlg::OnOK();

--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -758,10 +758,12 @@ _tstring CCommon::FileRename(const _tstring& file_path, const _tstring& new_file
 
 _tstring CCommon::RelativePathToAbsolutePath(const _tstring & relative_path, const _tstring & cur_dir)
 {
-    //
+    // relative_path如果是绝对路径那么返回此绝对路径
+	// 否则将relative_path视为相对路径并试着与cur_dir正确拼接
     _tstring result = relative_path;
     _tstring dir = cur_dir;
-    if (dir.empty() || dir.back() != _T('\\') || dir.back() != _T('/'))
+	// 如果dir不为空那么确保dir结尾有路径分隔符
+    if (!dir.empty() && (dir.back() != _T('\\') || dir.back() != _T('/')))
         dir.push_back(_T('\\'));
     if ((result.size() > 0 && (result.front() == _T('.') || result.front() == _T('\\') || result.front() == _T('/'))))        //如果是相对路径
     {

--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -4,6 +4,7 @@
 #include "FilePathHelper.h"
 #include <random>
 #include <functional>
+// #include <pathcch.h>
 
 CCommon::CCommon()
 {
@@ -758,24 +759,19 @@ _tstring CCommon::FileRename(const _tstring& file_path, const _tstring& new_file
 
 _tstring CCommon::RelativePathToAbsolutePath(const _tstring & relative_path, const _tstring & cur_dir)
 {
-    // relative_path如果是绝对路径那么返回此绝对路径
-	// 否则将relative_path视为相对路径并试着与cur_dir正确拼接
+    // relative_path如果是盘符开头的绝对路径那么返回此绝对路径
+    // 否则将relative_path视为相对路径或斜杠开头的绝对路径并与cur_dir拼接
     _tstring result = relative_path;
     _tstring dir = cur_dir;
-	// 如果dir不为空那么确保dir结尾有路径分隔符
-    if (!dir.empty() && (dir.back() != _T('\\') || dir.back() != _T('/')))
-        dir.push_back(_T('\\'));
-    if ((result.size() > 0 && (result.front() == _T('.') || result.front() == _T('\\') || result.front() == _T('/'))))        //如果是相对路径
+    if (!IsWindowsPath(result) && !dir.empty())
     {
-        if (result.front() == _T('.') && (result.size() == 1 || result[1] != _T('.')))  //如果路径前面是一个点而不是两个点，则把点去掉
-            result = result.substr(1);
-        if (result.size() > 0 && (result.front() == _T('\\') || result.front() == _T('/')))
-            result = result.substr(1);
-        result = dir + result;
-    }
-    else if (!IsWindowsPath(result))
-    {
-        result = dir + result;
+        // https://docs.microsoft.com/en-us/windows/win32/api/shlwapi/
+        // PathCombine拼接简化两个合法路径，当result为斜杠开头的绝对路径时将其只与dir的盘符拼接
+        // PathCchCombine 是处理了缓冲区溢出的安全版本，Windows 8开始支持，位于pathcch.h
+        TCHAR lpBuffer[MAX_PATH]{};
+        PathCombine(lpBuffer, dir.c_str(), result.c_str());
+        // PathCchCombine(lpBuffer, MAX_PATH, dir.c_str(), result.c_str());
+        result = lpBuffer;
     }
     return result;
 }

--- a/MusicPlayer2/MusicPlayerCmdHelper.cpp
+++ b/MusicPlayer2/MusicPlayerCmdHelper.cpp
@@ -450,20 +450,15 @@ std::wstring CMusicPlayerCmdHelper::SearchAlbumCover(const SongInfo& song)
             {
                 if (!album_name.empty())
                 {
-                    file_name = dir + album_name + L".*";
+                    file_name = CCommon::RelativePathToAbsolutePath(album_name + L".*", dir);
                     CCommon::GetImageFiles(file_name, files);
                 }
                 if (!files.empty())
                 {
                     // 处理album_name可能含有相对路径的情况，files[0]仅有文件名
                     // 由于album_name中文件名部分可能含有通配符所以不能只替换后缀，需要替换整个文件名
-                    // 如果album_name是简写则处理不变，若是相对路径则拼接整理交给RelativePathToAbsolutePath进行
-                    size_t index;
-                    index = album_name.rfind('\\');
-                    if (index == wstring::npos)
-                        album_cover_path = dir + files[0];
-                    else
-                        album_cover_path = CCommon::RelativePathToAbsolutePath(album_name.substr(0, index + 1) + files[0], dir);
+                    size_t index = file_name.rfind('\\');
+                    album_cover_path = file_name.substr(0, index + 1) + files[0];
                     break;
                 }
             }

--- a/MusicPlayer2/MusicPlayerCmdHelper.cpp
+++ b/MusicPlayer2/MusicPlayerCmdHelper.cpp
@@ -441,8 +441,10 @@ std::wstring CMusicPlayerCmdHelper::SearchAlbumCover(const SongInfo& song)
             file_name = dir + album_name + L".*";
             CCommon::GetImageFiles(file_name, files);
         }
-        //没有找到唱片集为文件名的文件，查找文件名为设置的专辑封面名的文件
-        if (theApp.m_app_setting_data.use_out_image && files.empty())
+        if (!files.empty())
+            album_cover_path = dir + files[0];
+        // 没有找到唱片集为文件名的文件，查找文件名为设置的专辑封面名的文件
+        else if (theApp.m_app_setting_data.use_out_image)
         {
             for (const auto& album_name : theApp.m_app_setting_data.default_album_name)
             {
@@ -454,19 +456,18 @@ std::wstring CMusicPlayerCmdHelper::SearchAlbumCover(const SongInfo& song)
                 if (!files.empty())
                 {
                     // 处理album_name可能含有相对路径的情况，files[0]仅有文件名
+                    // 由于album_name中文件名部分可能含有通配符所以不能只替换后缀，需要替换整个文件名
+                    // 如果album_name是简写则处理不变，若是相对路径则拼接整理交给RelativePathToAbsolutePath进行
                     size_t index;
                     index = album_name.rfind('\\');
-                    if (index != wstring::npos)
-                    {
-                        // 由于album_name可能含有通配符所以不能只替换后缀，需要替换整个文件名
-                        files[0] = album_name.substr(0, index + 1) + files[0];
-                    }
+                    if (index == wstring::npos)
+                        album_cover_path = dir + files[0];
+                    else
+                        album_cover_path = CCommon::RelativePathToAbsolutePath(album_name.substr(0, index + 1) + files[0], dir);
                     break;
                 }
             }
         }
-        if (!files.empty())
-            album_cover_path = dir + files[0];
     }
     return album_cover_path;
 }

--- a/MusicPlayer2/MusicPlayerCmdHelper.cpp
+++ b/MusicPlayer2/MusicPlayerCmdHelper.cpp
@@ -442,16 +442,26 @@ std::wstring CMusicPlayerCmdHelper::SearchAlbumCover(const SongInfo& song)
             CCommon::GetImageFiles(file_name, files);
         }
         //没有找到唱片集为文件名的文件，查找文件名为设置的专辑封面名的文件
-        if (theApp.m_app_setting_data.use_out_image)
+        if (theApp.m_app_setting_data.use_out_image && files.empty())
         {
             for (const auto& album_name : theApp.m_app_setting_data.default_album_name)
             {
-                if (!files.empty())
-                    break;
                 if (!album_name.empty())
                 {
                     file_name = dir + album_name + L".*";
                     CCommon::GetImageFiles(file_name, files);
+                }
+                if (!files.empty())
+                {
+                    // 处理album_name可能含有相对路径的情况，files[0]仅有文件名
+                    size_t index;
+                    index = album_name.rfind('\\');
+                    if (index != wstring::npos)
+                    {
+                        // 由于album_name可能含有通配符所以不能只替换后缀，需要替换整个文件名
+                        files[0] = album_name.substr(0, index + 1) + files[0];
+                    }
+                    break;
                 }
             }
         }


### PR DESCRIPTION
同时更改RelativePathToAbsolutePath使用PathCombine转换相对路径到绝对路径
能够自动简化路径，输入的dir和result也能够适应所有合法路径
PathCchCombine是处理了缓冲区溢出的安全版本，Windows 8开始支持，暂且写在注释里没有使用

更新：在添加通配符查找文件前先使用RelativePathToAbsolutePath转换为绝对路径
简化流程，顺便支持绝对路径，可能略微影响封面查找速度，鉴于没有急需搜索大量专辑封面的场景，个人感觉可以接受

现在可支持所有路径写法：
```
cover
*.png
.\Scans\01
.\Scans\*
.\..\cover
C:\part\to\cover.jpg
\part\to\*
```
图片文件名任意部分可以使用通配符
图片文件名允许省略后缀
路径中文件夹部分不允许通配符
斜杠开头的是绝对路径，会解释为当前播放音频文件所在盘符

有必要处理缓冲区溢出的可能性，水平有限不知如何处理

可以近似实现 #60 ，将一个绝对路径指定的图片放在最后，作为最后fall back