### PR TITLE
字符编码支持

### DIFF
--- a/MusicPlayer2/AudioTagOld.cpp
+++ b/MusicPlayer2/AudioTagOld.cpp
@@ -431,7 +431,7 @@ wstring CAudioTagOld::GetSpecifiedId3V2Tag(const string& tag_contents, const str
 		switch (tag_contents[tag_index + 10])
 		{
 		case 1: case 2:
-			default_code = CodeType::UTF16;
+			default_code = CodeType::UTF16LE;
 			break;
 		case 3:
 			default_code = CodeType::UTF8;
@@ -443,7 +443,7 @@ wstring CAudioTagOld::GetSpecifiedId3V2Tag(const string& tag_contents, const str
 		string tag_info_str;
 		if (tag_identify == "COMM" || tag_identify == "USLT")
 		{
-			if (default_code == CodeType::UTF16)
+			if (default_code == CodeType::UTF16LE)
 				tag_info_str = tag_contents.substr(tag_index + 18, tag_size - 8);
 			else
 				tag_info_str = tag_contents.substr(tag_index + 15, tag_size - 5);

--- a/MusicPlayer2/AudioTagOld.cpp
+++ b/MusicPlayer2/AudioTagOld.cpp
@@ -427,7 +427,7 @@ wstring CAudioTagOld::GetSpecifiedId3V2Tag(const string& tag_contents, const str
 		if (tag_index + 11 >= tag_contents.size())
 			return wstring();
 		//判断标签的编码格式
-		CodeType default_code, code_type;
+		CodeType default_code;
 		switch (tag_contents[tag_index + 10])
 		{
 		case 1: case 2:
@@ -452,8 +452,7 @@ wstring CAudioTagOld::GetSpecifiedId3V2Tag(const string& tag_contents, const str
 		{
 			tag_info_str = tag_contents.substr(tag_index + 11, tag_size - 1);
 		}
-		code_type = CCommon::JudgeCodeType(tag_info_str, default_code);
-		tag_info = CCommon::StrToUnicode(tag_info_str, code_type);
+		tag_info = CCommon::StrToUnicode(tag_info_str, default_code);
 	}
 	return tag_info;
 }

--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -331,9 +331,10 @@ size_t CCommon::GetFileSize(const wstring & file_name)
 
 wstring CCommon::StrToUnicode(const string& str, CodeType code_type, bool auto_utf8)
 {
-	// 仅当预先已知编码为当前系统ANSI，UTF8，UTF8_NO_BOM，UTF16LE，UTF16BE时使用对应选项
-	// 其他情况应当使用默认值CodeType::AUTO，没有外部判断的必要
-	// 如果发生AUTO将过短的ANSI误判为UTF8，将auto_utf8置false恢复AUTO旧行为将没有BOM的字串全部视为ANSI
+	// 当使用ANSI，UTF8，UTF8_NO_BOM，UTF16LE，UTF16BE时不检测直接转换
+	// 使用默认值CodeType::AUTO时先检测BOM，如果没有BOM则按ANSI转换
+	// 将auto_utf8置true使AUTO检测没有BOM的字串是否为UTF8序列，如果符合则按UTF8_NO_BOM转换
+	// auto_utf8有可能将过短的ANSI误认为是UTF8导致乱码
 	if (str.empty()) return wstring();
 	// code_type为AUTO时从这里开始
 	if (code_type == CodeType::AUTO)	// 先根据BOM判断编码类型
@@ -348,7 +349,7 @@ wstring CCommon::StrToUnicode(const string& str, CodeType code_type, bool auto_u
 		else if (str.size() >= 2 && str[0] == -2 && str[1] == -1)
 			code_type = CodeType::UTF16BE;
 		// AUTO时是否将符合UTF8格式的str作为UTF8_NO_BOM处理
-		else if (auto_utf8 ? IsUTF8Bytes(str.c_str()) : 0)
+		else if (auto_utf8 && IsUTF8Bytes(str.c_str()))
 			code_type = CodeType::UTF8_NO_BOM;
 	}
 	bool result_ready = false;

--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -332,8 +332,8 @@ size_t CCommon::GetFileSize(const wstring & file_name)
 wstring CCommon::StrToUnicode(const string& str, CodeType code_type, bool auto_utf8)
 {
 	// 仅当预先已知编码为当前系统ANSI，UTF8，UTF8_NO_BOM，UTF16LE，UTF16BE时使用对应选项
-	// 其他情况应当使用CodeType::AUTO，没有外部判断的必要
-	// 如果发生AUTO将过短的ASIC误判为UTF8，将auto_utf8置false恢复AUTO旧行为将没有BOM的字串全部视为ASIC
+	// 其他情况应当使用默认值CodeType::AUTO，没有外部判断的必要
+	// 如果发生AUTO将过短的ANSI误判为UTF8，将auto_utf8置false恢复AUTO旧行为将没有BOM的字串全部视为ANSI
 	if (str.empty()) return wstring();
 	// code_type为AUTO时从这里开始
 	if (code_type == CodeType::AUTO)	// 先根据BOM判断编码类型
@@ -448,10 +448,10 @@ string CCommon::UnicodeToStr(const wstring & wstr, CodeType code_type, bool* cha
 		result.append(str);
 		delete[] str;
 	}
-	else if (code_type == CodeType::UTF16)
+	else if (code_type == CodeType::UTF16LE)
 	{
 		result.clear();
-		result.push_back(-1);	//在前面加上UTF16的BOM
+		result.push_back(-1);	//在前面加上UTF16LE的BOM
 		result.push_back(-2);
 		result.append((const char*)wstr.c_str(), (const char*)wstr.c_str() + wstr.size() * 2);
 		result.push_back('\0');
@@ -516,9 +516,9 @@ CodeType CCommon::JudgeCodeType(const string & str, CodeType default_code)
 	//如果前面有UTF8的BOM，则编码类型为UTF8
 	if (str.size() >= 3 && str[0] == -17 && str[1] == -69 && str[2] == -65)
 		return CodeType::UTF8;
-	//如果前面有UTF16的BOM，则编码类型为UTF16
+	//如果前面有UTF16LE的BOM，则编码类型为UTF16LE
 	else if (str.size() >= 2 && str[0] == -1 && str[1] == -2)
-		return CodeType::UTF16;
+		return CodeType::UTF16LE;
 	//else if (IsUTF8Bytes(str.c_str()))		//如果没有找到UTF8和UTF16的BOM，则判断字符串是否有UTF8编码的特性
 	//	return CodeType::UTF8_NO_BOM;
 	else
@@ -1619,7 +1619,7 @@ CString CCommon::GetTextResource(UINT id, CodeType code_type)
         HGLOBAL hglobal = LoadResource(NULL, hRes);
         if (hglobal != NULL)
         {
-            if (code_type == CodeType::UTF16)
+            if (code_type == CodeType::UTF16LE)
             {
                 res_str = (const wchar_t*)hglobal;
             }

--- a/MusicPlayer2/Common.h
+++ b/MusicPlayer2/Common.h
@@ -39,8 +39,7 @@ enum class CodeType
 	ANSI,
 	UTF8,
 	UTF8_NO_BOM,
-	UTF16 = 3,
-	UTF16LE = 3,
+	UTF16LE,
 	UTF16BE,
 	AUTO
 };

--- a/MusicPlayer2/Common.h
+++ b/MusicPlayer2/Common.h
@@ -39,7 +39,9 @@ enum class CodeType
 	ANSI,
 	UTF8,
 	UTF8_NO_BOM,
-	UTF16,
+	UTF16 = 3,
+	UTF16LE = 3,
+	UTF16BE,
 	AUTO
 };
 
@@ -146,6 +148,18 @@ public:
 
 	//将string类型的字符串转换成Unicode编码的wstring字符串
 	static wstring StrToUnicode(const string& str, CodeType code_type = CodeType::AUTO);
+
+	//将UTF16BE转换为UTF16LE
+	static inline void convertBEtoLE(wchar_t* bigEndianBuffer, unsigned int length)
+	{
+		for (unsigned int i = 0; i < length; ++i)
+		{
+			unsigned char* chr = (unsigned char*)(bigEndianBuffer + i);
+			unsigned char temp = *chr;
+			*chr = *(chr + 1);
+			*(chr + 1) = temp;
+		}
+	}
 
 	//将Unicode编码的wstring字符串转换成string类型的字符串，如果有字符无法转换，将参数char_cannot_convert指向的bool变量置为true
 	static string UnicodeToStr(const wstring & wstr, CodeType code_type, bool* char_cannot_convert = nullptr);

--- a/MusicPlayer2/Common.h
+++ b/MusicPlayer2/Common.h
@@ -147,7 +147,7 @@ public:
 	static size_t GetFileSize(const wstring& file_name);
 
 	//将string类型的字符串转换成Unicode编码的wstring字符串
-	static wstring StrToUnicode(const string& str, CodeType code_type = CodeType::AUTO);
+	static wstring StrToUnicode(const string& str, CodeType code_type = CodeType::AUTO, bool auto_utf8 = true);
 
 	//将UTF16BE转换为UTF16LE
 	static inline void convertBEtoLE(wchar_t* bigEndianBuffer, unsigned int length)

--- a/MusicPlayer2/Common.h
+++ b/MusicPlayer2/Common.h
@@ -146,7 +146,7 @@ public:
 	static size_t GetFileSize(const wstring& file_name);
 
 	//将string类型的字符串转换成Unicode编码的wstring字符串
-	static wstring StrToUnicode(const string& str, CodeType code_type = CodeType::AUTO, bool auto_utf8 = true);
+	static wstring StrToUnicode(const string& str, CodeType code_type = CodeType::AUTO, bool auto_utf8 = false);
 
 	//将UTF16BE转换为UTF16LE
 	static inline void convertBEtoLE(wchar_t* bigEndianBuffer, unsigned int length)

--- a/MusicPlayer2/CueFile.cpp
+++ b/MusicPlayer2/CueFile.cpp
@@ -17,8 +17,8 @@ CCueFile::CCueFile(const std::wstring& file_path)
         file_content.push_back(ch);
         if (file_content.size() > 102400) break;	//限制cue文件最大为100KB
     }
-
-    m_file_content_wcs = CCommon::StrToUnicode(file_content, m_code_type);
+    // cue文件较长可以自动检测是否符合UTF8编码
+    m_file_content_wcs = CCommon::StrToUnicode(file_content, m_code_type, true);
 
     DoAnalysis();
 }

--- a/MusicPlayer2/CueFile.cpp
+++ b/MusicPlayer2/CueFile.cpp
@@ -17,12 +17,6 @@ CCueFile::CCueFile(const std::wstring& file_path)
         file_content.push_back(ch);
         if (file_content.size() > 102400) break;	//限制cue文件最大为100KB
     }
-    if (file_content.size() >= 3 && file_content[0] == '\xef' && file_content[1] == '\xbb' && file_content[2] == '\xbf')
-        m_code_type = CodeType::UTF8;
-    else if (file_content.size() >= 2 && file_content[0] == '\xff' && file_content[1] == '\xfe')
-        m_code_type = CodeType::UTF16;
-    else if (CCommon::IsUTF8Bytes(file_content.c_str()))
-        m_code_type = CodeType::UTF8_NO_BOM;
 
     m_file_content_wcs = CCommon::StrToUnicode(file_content, m_code_type);
 

--- a/MusicPlayer2/LyricEditDlg.cpp
+++ b/MusicPlayer2/LyricEditDlg.cpp
@@ -174,7 +174,8 @@ void CLyricEditDlg::UpdateStatusbarInfo()
 	case CodeType::ANSI: str += _T("ANSI"); break;
 	case CodeType::UTF8: str += _T("UTF8"); break;
 	case CodeType::UTF8_NO_BOM: str += CCommon::LoadText(IDS_UTF8_NO_BOM); break;
-	case CodeType::UTF16: str += _T("UTF16"); break;
+	case CodeType::UTF16LE: str += _T("UTF16LE"); break;
+	case CodeType::UTF16BE: str += _T("UTF16BE"); break;
 	}
 	m_status_bar.SetText(str, 2, 0);
 }

--- a/MusicPlayer2/SimpleXML.cpp
+++ b/MusicPlayer2/SimpleXML.cpp
@@ -18,20 +18,8 @@ CSimpleXML::CSimpleXML(const wstring & xml_path)
 	xml_str.pop_back();
 	if (!xml_str.empty() && xml_str.back() != L'\n')		//确保文件末尾有回车符
 		xml_str.push_back(L'\n');
-	//判断文件是否是utf8编码
-	bool is_utf8;
-	if (xml_str.size() >= 3 && xml_str[0] == -17 && xml_str[1] == -69 && xml_str[2] == -65)
-	{
-		//如果有UTF8的BOM，则删除BOM
-		is_utf8 = true;
-		xml_str = xml_str.substr(3);
-	}
-	else
-	{
-		is_utf8 = false;
-	}
 	//转换成Unicode
-	m_xml_content = CCommon::StrToUnicode(xml_str.c_str(), (is_utf8 ? CodeType::UTF8_NO_BOM : CodeType::ANSI));
+	m_xml_content = CCommon::StrToUnicode(xml_str.c_str());
 }
 
 CSimpleXML::CSimpleXML()


### PR DESCRIPTION
添加UTF16BE with BOM支持，更改源码中所有CodeType::UTF16为CodeType::UTF16LE
整理各处编码识别集中到CCommon::StrToUnicode，歌词编码识别那个独立的较快的算法没有改，CCommon::JudgeCodeType不再使用
更改CCommon::StrToUnicode参数为AUTO时的行为
原行为：检测BOM->不匹配就作为ANSI处理
改动后：检测BOM->不匹配检测是否为UTF8序列->不匹配则按ANSI处理

已检查所有以默认参数调用StrToUnicode方法的位置，可以确认更改前后行为不变
未能确认的部分：
BassCore.cpp中以默认参数AUTO调用StrToUnicode方法时传入字串是否为ANSI
如果以下传入是ANSI，那么改动后碰巧此字段符合UTF8模式会乱码，需要第三个参数auto_utf8=false来恢复原行为
获取当前的音频输出设备：
device.name = CCommon::StrToUnicode(string(device_info.name));  
device.driver = CCommon::StrToUnicode(string(device_info.driver));
MIDI音色库：
m_sfont_name = CCommon::StrToUnicode(sfount_info.name);
midi音乐标题：
song_info.title = CCommon::StrToUnicode(mark.text);
