### PR TITLE
播放列表展开cue条目时的处理

### DIFF
--- a/MusicPlayer2/AudioCommon.h
+++ b/MusicPlayer2/AudioCommon.h
@@ -121,8 +121,8 @@ public:
 	//查找path目录下的所有歌词文件，并将文件名保存到files容器中
 	static void GetLyricFiles(wstring path, vector<wstring>& files);
 
-	//处理files容器中的cue文件，并将每段分轨作为一个曲目添加到files容器中
-	static void GetCueTracks(vector<SongInfo>& files, IPlayerCore* pPlayerCore);
+	//处理files容器中的cue文件，并将每段分轨作为一个曲目添加到files容器中，同时维护播放索引位置
+	static void GetCueTracks(vector<SongInfo>& files, IPlayerCore* pPlayerCore, int& index);
 
 	//获得标准流派信息
 	static wstring GetGenre(BYTE genre);
@@ -159,6 +159,6 @@ public:
 
 protected:
     //获取音频文件的内嵌cue文件，并将每段分轨作为一个曲目添加到files容器中
-    static void GetInnerCueTracks(vector<SongInfo>& files, IPlayerCore* pPlayerCore);
+    static void GetInnerCueTracks(vector<SongInfo>& files, IPlayerCore* pPlayerCore, int& index);
 };
 

--- a/MusicPlayer2/Player.cpp
+++ b/MusicPlayer2/Player.cpp
@@ -306,6 +306,7 @@ void CPlayer::IniPlaylistComplate()
 	//if(!sort)		//如果文件是通过命令行参数打开的，则sort会为false，此时打开后直接播放
 	//    MusicControl(Command::PLAY);
 
+	SaveCurrentPlaylist();
 	EmplaceCurrentPathToRecent();
 	EmplaceCurrentPlaylistToRecent();
 	SetTitle();

--- a/MusicPlayer2/Player.cpp
+++ b/MusicPlayer2/Player.cpp
@@ -217,7 +217,7 @@ UINT CPlayer::IniPlaylistThreadFunc(LPVOID lpParam)
 
 void CPlayer::IniPlaylistComplate()
 {
-	CAudioCommon::GetCueTracks(m_playlist, m_pCore);
+	CAudioCommon::GetCueTracks(m_playlist, m_pCore, m_index_tmp);
 	//m_song_num = m_playlist.size();
 	m_index = m_index_tmp;
 	if (m_index < 0 || m_index >= GetSongNum()) m_index = 0;		//确保当前歌曲序号不会超过歌曲总数


### PR DESCRIPTION
命令行添加文件时的OpenFiles直接从文件载入播放列表之后加上来自命令行的条目（可能含有未展开的cue）后存回文件。
之后由IniPlaylistComplate进行cue展开，这里添加一个播放列表存回文件的操作。
这样下次命令行添加时就能读到已展开cue的文件，而不是未展开cue的文件。

直接双击已经正常，但并没有完全解决116的问题，
按我的理解在`CAudioCommon::GetCueTracks(m_playlist, m_pCore);`
前后维护`m_index_tmp`在正确的合理位置才是问题本身，涉及cue的各种可能性比较麻烦，~在写~在研究
