### PR TITLE
编辑歌曲文件前取消只读

### DIFF
--- a/MusicPlayer2/AudioTag.cpp
+++ b/MusicPlayer2/AudioTag.cpp
@@ -271,6 +271,7 @@ wstring CAudioTag::GetAudioLyric()
 
 bool CAudioTag::WriteAudioLyric(const wstring& lyric_contents)
 {
+    CCommon::SetFileReadOnly(m_song_info.file_path, false);
     switch (m_type)
     {
     case AU_MP3:
@@ -292,6 +293,7 @@ bool CAudioTag::WriteAudioLyric(const wstring& lyric_contents)
 bool CAudioTag::WriteAudioTag()
 {
     //AudioType type = CAudioCommon::GetAudioTypeByFileName(m_song_info.file_path);
+    CCommon::SetFileReadOnly(m_song_info.file_path, false);
     switch (m_type)
     {
     case AU_MP3:
@@ -331,6 +333,7 @@ bool CAudioTag::WriteAudioTag()
 
 bool CAudioTag::WriteAlbumCover(const wstring& album_cover_path)
 {
+    CCommon::SetFileReadOnly(m_song_info.file_path, false);
     switch (m_type)
     {
     case AU_MP3:
@@ -392,6 +395,7 @@ void CAudioTag::GetAudioRating()
 
 void CAudioTag::WriteAudioRating()
 {
+    CCommon::SetFileReadOnly(m_song_info.file_path, false);
     switch (m_type)
     {
     case AU_MP3:

--- a/MusicPlayer2/AudioTag.h
+++ b/MusicPlayer2/AudioTag.h
@@ -24,6 +24,7 @@ public:
     //获取音频的内嵌歌词
     wstring GetAudioLyric();
 
+    //写入内嵌歌词
     bool WriteAudioLyric(const wstring& lyric_contents);
 
     AudioType GetAudioType() const { return m_type; }

--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -783,6 +783,14 @@ _tstring CCommon::FileRename(const _tstring& file_path, const _tstring& new_file
     return new_file_path;
 }
 
+bool CCommon::SetFileReadOnly(const wstring& file_path, bool read_only)
+{
+    DWORD dwFileAttributes{ GetFileAttributesW(file_path.c_str()) };
+    if (read_only == (dwFileAttributes & FILE_ATTRIBUTE_READONLY))
+        return false;
+    return SetFileAttributesW(file_path.c_str(), dwFileAttributes ^ FILE_ATTRIBUTE_READONLY);
+}
+
 _tstring CCommon::RelativePathToAbsolutePath(const _tstring & relative_path, const _tstring & cur_dir)
 {
     // relative_path如果是盘符开头的绝对路径那么返回此绝对路径

--- a/MusicPlayer2/Common.h
+++ b/MusicPlayer2/Common.h
@@ -229,6 +229,9 @@ public:
     //成功则返回新文件/文件夹的路径，否则返回空字符串
     static _tstring FileRename(const _tstring& file_path, const _tstring& new_file_name);
 
+    //设置文件只读属性，若只读属性改变返回true
+    static bool SetFileReadOnly(const wstring& file_path, bool read_only);
+
     //将相对路径转换成绝对路径
     //会自动判断路径是否为相对路径，如果不是则直接返回原路径
     //relative_path：要转换的路径


### PR DESCRIPTION
虽然只读属性本身是用来限制写入的，不过就MusicPlayer2来说用户已经做出了编辑的指示应该可以忽略属性进行编辑。
没有在编辑后还原属性（感觉没什么必要）需要可以加。