### PR TITLE
一些播放列表修正

### DIFF
--- a/MusicPlayer2/CSelectPlaylist.cpp
+++ b/MusicPlayer2/CSelectPlaylist.cpp
@@ -27,6 +27,7 @@ CSelectPlaylistDlg::~CSelectPlaylistDlg()
 
 void CSelectPlaylistDlg::RefreshSongList()
 {
+    ShowPathList();     // 对播放列表列表刷新特别处理，刷新左侧列表
     ShowSongList();
 }
 
@@ -48,11 +49,6 @@ int CSelectPlaylistDlg::GetPosition() const
 bool CSelectPlaylistDlg::IsPlaylistModified() const
 {
     return m_playlist_modified;
-}
-
-void CSelectPlaylistDlg::SetUpdateFlag()
-{
-	m_update_flag = true;
 }
 
 void CSelectPlaylistDlg::AdjustColumnWidth()
@@ -123,8 +119,6 @@ void CSelectPlaylistDlg::OnTabEntered()
     if(m_playlist_ctrl.GetCurSel() != -1)
         m_row_selected = m_playlist_ctrl.GetCurSel();
     SetButtonsEnable();
-	if (m_update_flag)
-		ShowPathList();
 }
 
 void CSelectPlaylistDlg::ShowSongList()
@@ -307,6 +301,7 @@ BOOL CSelectPlaylistDlg::OnInitDialog()
 
     m_row_selected = GetPlayingItem(); // 初始化时选中正在播放的播放列表
     ShowPathList();
+    ShowSongList();
     m_search_edit.SetFocus();		//初始时将焦点设置到搜索框
     m_search_edit.SetCueBanner(CCommon::LoadText(IDS_SEARCH_HERE), TRUE);
 
@@ -407,8 +402,6 @@ void CSelectPlaylistDlg::ShowPathList()
         }
     }
     m_playlist_ctrl.SetHightItem(GetPlayingItem());
-    ShowSongList();
-	m_update_flag = false;
 }
 
 void CSelectPlaylistDlg::SetListRowData(int index, const PlaylistInfo& playlist_info)

--- a/MusicPlayer2/CSelectPlaylist.cpp
+++ b/MusicPlayer2/CSelectPlaylist.cpp
@@ -184,6 +184,9 @@ void CSelectPlaylistDlg::LeftListClicked(int index)
         str = m_playlist_ctrl.GetItemText(index, 0);
         m_row_selected = _ttoi(str) - 1;
     }
+    m_right_selected_item = -1;         // 点击左侧列表时清空右侧列表选中项
+    m_right_selected_items.clear();
+    m_song_list_ctrl.SelectNone();
     SetButtonsEnable();
     ShowSongList();
 }
@@ -445,10 +448,10 @@ bool CSelectPlaylistDlg::SelectValid() const
     if (m_row_selected == 0 || m_row_selected == 1)
         return true;
     int index = m_row_selected - SPEC_PLAYLIST_NUM;
-    int playlist_size{ static_cast<int>(CPlayer::GetInstance().GetRecentPlaylist().m_recent_playlists.size()) };
+    int playlists_size{ static_cast<int>(CPlayer::GetInstance().GetRecentPlaylist().m_recent_playlists.size()) };
     // 对一般播放列表返回true，对临时播放列表仅当列表不为空时返回true
-    return ((index >= 0 && index < playlist_size) ||
-        (index == playlist_size && CPlayer::GetInstance().GetRecentPlaylist().m_temp_playlist.track_num > 0));
+    return ((index >= 0 && index < playlists_size) ||
+        (index == playlists_size && CPlayer::GetInstance().GetRecentPlaylist().m_temp_playlist.track_num > 0));
 }
 
 PlaylistInfo CSelectPlaylistDlg::GetSelectedPlaylist() const
@@ -629,8 +632,8 @@ void CSelectPlaylistDlg::OnDeletePlaylist()
 {
     // TODO: 在此添加命令处理程序代码
     int index{ m_row_selected - SPEC_PLAYLIST_NUM };
-    int playlist_size{ static_cast<int>(CPlayer::GetInstance().GetRecentPlaylist().m_recent_playlists.size()) };
-    if (index >= 0 && index < playlist_size)
+    int playlists_size{ static_cast<int>(CPlayer::GetInstance().GetRecentPlaylist().m_recent_playlists.size()) };
+    if (index >= 0 && index < playlists_size)
     {
         wstring playlist_path = CPlayer::GetInstance().GetRecentPlaylist().m_recent_playlists[index].path;
         if (playlist_path == CPlayer::GetInstance().GetPlaylistPath())      //如果删除的是正在播放的播放列表，则播放默认播放列表
@@ -642,7 +645,7 @@ void CSelectPlaylistDlg::OnDeletePlaylist()
         ShowPathList();
         m_playlist_modified = true;
     }
-    else if (index == playlist_size)           // 删除的是临时播放列表
+    else if (index == playlists_size)           // 删除的是临时播放列表
     {
         if (CPlayer::GetInstance().GetRecentPlaylist().m_cur_playlist_type == PT_TEMP)
         {
@@ -687,9 +690,9 @@ void CSelectPlaylistDlg::OnInitMenu(CMenu* pMenu)
     CMediaLibTabDlg::OnInitMenu(pMenu);
 
     // TODO: 在此处添加消息处理程序代码
-    auto playlist_size{ CPlayer::GetInstance().GetRecentPlaylist().m_recent_playlists.size() + SPEC_PLAYLIST_NUM };
-    bool is_not_default_playlist{ m_row_selected > 1 && m_row_selected < playlist_size };
-    bool is_tmp_playlist{ m_row_selected == playlist_size };
+    int playlists_size{ static_cast<int>(CPlayer::GetInstance().GetRecentPlaylist().m_recent_playlists.size()) + SPEC_PLAYLIST_NUM };
+    bool is_not_default_playlist{ m_row_selected > 1 && m_row_selected < playlists_size };
+    bool is_tmp_playlist{ m_row_selected == playlists_size };
     pMenu->EnableMenuItem(ID_RENAME_PLAYLIST, MF_BYCOMMAND | (is_not_default_playlist ? MF_ENABLED : MF_GRAYED));
     pMenu->EnableMenuItem(ID_DELETE_PLAYLIST, MF_BYCOMMAND | (is_not_default_playlist || is_tmp_playlist ? MF_ENABLED : MF_GRAYED));
     pMenu->EnableMenuItem(ID_PLAY_PLAYLIST, MF_BYCOMMAND | (SelectedCanPlay() ? MF_ENABLED : MF_GRAYED));

--- a/MusicPlayer2/CSelectPlaylist.cpp
+++ b/MusicPlayer2/CSelectPlaylist.cpp
@@ -800,4 +800,8 @@ void CSelectPlaylistDlg::OnCancel()
     // TODO: 在此添加专用代码和/或调用基类
 
     CTabDlg::OnCancel();
+
+    CWnd* pParent = GetParentWindow();
+    if (pParent != nullptr)
+        ::SendMessage(pParent->GetSafeHwnd(), WM_COMMAND, IDCANCEL, 0);
 }

--- a/MusicPlayer2/CSelectPlaylist.cpp
+++ b/MusicPlayer2/CSelectPlaylist.cpp
@@ -120,7 +120,8 @@ int CSelectPlaylistDlg::GetPlayingItem()
 
 void CSelectPlaylistDlg::OnTabEntered()
 {
-    m_row_selected = m_playlist_ctrl.GetCurSel();
+    if(m_playlist_ctrl.GetCurSel() != -1)
+        m_row_selected = m_playlist_ctrl.GetCurSel();
     SetButtonsEnable();
 	if (m_update_flag)
 		ShowPathList();

--- a/MusicPlayer2/CSelectPlaylist.cpp
+++ b/MusicPlayer2/CSelectPlaylist.cpp
@@ -90,19 +90,19 @@ void CSelectPlaylistDlg::QuickSearch(const wstring& key_words)
     }
 }
 
-void CSelectPlaylistDlg::SetHighlightItem()
+int CSelectPlaylistDlg::GetPlayingItem()
 {
+    //正在播放的项目
+    int playing_item{ -1 };
     if (CPlayer::GetInstance().IsPlaylistMode() && !m_searched)
     {
-        //正在播放的项目
-        int highlight_item;
         if (CPlayer::GetInstance().GetRecentPlaylist().m_cur_playlist_type == PT_DEFAULT)
         {
-            highlight_item = 0;
+            playing_item = 0;
         }
         else if (CPlayer::GetInstance().GetRecentPlaylist().m_cur_playlist_type == PT_FAVOURITE)
         {
-            highlight_item = 1;
+            playing_item = 1;
         }
         else
         {
@@ -112,14 +112,10 @@ void CSelectPlaylistDlg::SetHighlightItem()
             {
                 return current_playlist == playlist_info.path;
             });
-            highlight_item = iter - recent_playlist.begin() + SPEC_PLAYLIST_NUM;
+            playing_item = iter - recent_playlist.begin() + SPEC_PLAYLIST_NUM;
         }
-        m_playlist_ctrl.SetHightItem(highlight_item);
     }
-    else
-    {
-        m_playlist_ctrl.SetHightItem(-1);
-    }
+    return playing_item;
 }
 
 void CSelectPlaylistDlg::OnTabEntered()
@@ -308,6 +304,7 @@ BOOL CSelectPlaylistDlg::OnInitDialog()
     m_song_list_ctrl.InsertColumn(COL_PATH, CCommon::LoadText(IDS_FILE_PATH), LVCFMT_LEFT, theApp.DPI(600));
     m_song_list_ctrl.SetCtrlAEnable(true);
 
+    m_row_selected = GetPlayingItem(); // 初始化时选中正在播放的播放列表
     ShowPathList();
     m_search_edit.SetFocus();		//初始时将焦点设置到搜索框
     m_search_edit.SetCueBanner(CCommon::LoadText(IDS_SEARCH_HERE), TRUE);
@@ -408,8 +405,8 @@ void CSelectPlaylistDlg::ShowPathList()
             SetListRowData(i, recent_playlists[m_search_result[i]]);
         }
     }
+    m_playlist_ctrl.SetHightItem(GetPlayingItem());
     ShowSongList();
-    SetHighlightItem();
 	m_update_flag = false;
 }
 

--- a/MusicPlayer2/CSelectPlaylist.h
+++ b/MusicPlayer2/CSelectPlaylist.h
@@ -34,7 +34,7 @@ public:
     bool IsLeftSelected() const;
 
 private:
-    int m_row_selected{};
+    int m_row_selected{ -1 };
     //CMenu m_menu;
     bool m_playlist_modified{ false };
     CSearchEditCtrl m_search_edit;
@@ -73,7 +73,7 @@ private:
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV 支持
     void QuickSearch(const wstring& key_words);		//根据关键字执行快速查找m_search_result中
-    void SetHighlightItem();
+    int GetPlayingItem();
     virtual void OnTabEntered() override;
     void ShowSongList();
 

--- a/MusicPlayer2/CSelectPlaylist.h
+++ b/MusicPlayer2/CSelectPlaylist.h
@@ -29,7 +29,6 @@ public:
     int GetTrack() const;
     int GetPosition() const;
     bool IsPlaylistModified() const;
-	void SetUpdateFlag();		//设置需要更新标志，当标签切换到此对话框时，会更新一次数据
     void AdjustColumnWidth();       //自动调整列表宽度
     bool IsLeftSelected() const;
 
@@ -41,7 +40,6 @@ private:
     vector<int> m_search_result;			//储存快速搜索结果的歌曲序号
     bool m_searched{ false };				//是否处理搜索状态
     //CToolTipCtrl m_Mytip;
-	bool m_update_flag{ false };
     bool m_left_selected{};                   //最后一次选中的是左侧还是右侧
     int m_right_selected_item{ -1 };
     std::vector<int> m_right_selected_items;   //右侧列表选中的项目的序号

--- a/MusicPlayer2/FolderExploreDlg.cpp
+++ b/MusicPlayer2/FolderExploreDlg.cpp
@@ -143,6 +143,9 @@ void CFolderExploreDlg::FolderTreeClicked(HTREEITEM hItem)
         m_folder_path_selected = folder_path_selected;
         ShowSongList();
     }
+    m_right_selected_item = -1;         // 点击左侧列表时清空右侧列表选中项
+    m_right_selected_items.clear();
+    m_song_list_ctrl.SelectNone();
     SetButtonsEnable(CCommon::FolderExist(wstring(folder_path_selected)));
 }
 

--- a/MusicPlayer2/ListCtrlEx.cpp
+++ b/MusicPlayer2/ListCtrlEx.cpp
@@ -350,12 +350,13 @@ BOOL CListCtrlEx::PreTranslateMessage(MSG* pMsg)
 	//if (pMsg->message == WM_KEYDOWN || pMsg->message == WM_CHAR)		//屏蔽列表控件的键盘消息，防止每次按下一个键时列表选中行会出现讨厌的、难看的虚线框
 	//	return TRUE;
 
-	//按Ctrl+A全选
+    // 按Ctrl+A全选，由于需要在父窗口使用GetPlaylistItemSelected更新m_items_selected，此处仅发全选消息
 	if(m_enable_ctrl_a)
 	{
 		if ((GetKeyState(VK_CONTROL) & 0x80) && (pMsg->wParam == 'A'))
 		{
-			SelectAll();
+            CWnd* pParent{ GetParent() };
+            pParent->SendMessage(WM_COMMAND, ID_PLAYLIST_SELECT_ALL);
 			return TRUE;
 		}
 	}

--- a/MusicPlayer2/ListCtrlEx.cpp
+++ b/MusicPlayer2/ListCtrlEx.cpp
@@ -350,15 +350,16 @@ BOOL CListCtrlEx::PreTranslateMessage(MSG* pMsg)
 	//if (pMsg->message == WM_KEYDOWN || pMsg->message == WM_CHAR)		//屏蔽列表控件的键盘消息，防止每次按下一个键时列表选中行会出现讨厌的、难看的虚线框
 	//	return TRUE;
 
-    // 按Ctrl+A全选，由于需要在父窗口使用GetPlaylistItemSelected更新m_items_selected，此处仅发全选消息
+    // 按Ctrl+A全选，向父窗口发送选中项更新消息
 	if(m_enable_ctrl_a)
 	{
 		if ((GetKeyState(VK_CONTROL) & 0x80) && (pMsg->wParam == 'A'))
 		{
+            SelectAll();
             CWnd* pParent{ GetParent() };
             if (pParent != nullptr)
             {
-                pParent->SendMessage(WM_COMMAND, ID_PLAYLIST_SELECT_ALL);
+                pParent->SendMessage(WM_COMMAND, ID_PLAYLIST_SELECT_CHANGE);
             }
 			return TRUE;
 		}

--- a/MusicPlayer2/ListCtrlEx.cpp
+++ b/MusicPlayer2/ListCtrlEx.cpp
@@ -356,7 +356,10 @@ BOOL CListCtrlEx::PreTranslateMessage(MSG* pMsg)
 		if ((GetKeyState(VK_CONTROL) & 0x80) && (pMsg->wParam == 'A'))
 		{
             CWnd* pParent{ GetParent() };
-            pParent->SendMessage(WM_COMMAND, ID_PLAYLIST_SELECT_ALL);
+            if (pParent != nullptr)
+            {
+                pParent->SendMessage(WM_COMMAND, ID_PLAYLIST_SELECT_ALL);
+            }
 			return TRUE;
 		}
 	}

--- a/MusicPlayer2/MediaClassifyDlg.cpp
+++ b/MusicPlayer2/MediaClassifyDlg.cpp
@@ -277,6 +277,9 @@ void CMediaClassifyDlg::ClassifyListClicked(int index)
         last_selected_index = index;
         last_selected_count = m_left_selected_items.size();
     }
+    m_right_selected_item = -1;           // 点击左侧列表时清空右侧列表选中项
+    m_right_selected_items.clear();
+    m_song_list_ctrl.SelectNone();
 
     SetButtonsEnable(/*(index >= 0 && index < m_classify_list_ctrl.GetItemCount()) ||*/ !m_left_selected_items.empty());
 

--- a/MusicPlayer2/MiniModeDlg.cpp
+++ b/MusicPlayer2/MiniModeDlg.cpp
@@ -516,11 +516,11 @@ void CMiniModeDlg::OnNMDblclkList2(NMHDR *pNMHDR, LRESULT *pResult)
 {
     LPNMITEMACTIVATE pNMItemActivate = reinterpret_cast<LPNMITEMACTIVATE>(pNMHDR);
     // TODO: 在此添加控件通知处理程序代码
-    int row = pNMItemActivate->iItem;
-    CPlayer::GetInstance().PlayTrack(row);
-    //SwitchTrack();
-    SetPlayListColor();
-    //RePaint();
+    if (pNMItemActivate->iItem < 0)
+        return;
+    m_item_selected = pNMItemActivate->iItem;
+    theApp.m_pMainWnd->SendMessage(WM_COMMAND, ID_PLAY_ITEM);
+
     *pResult = 0;
 }
 

--- a/MusicPlayer2/MiniModeDlg.cpp
+++ b/MusicPlayer2/MiniModeDlg.cpp
@@ -642,9 +642,8 @@ BOOL CMiniModeDlg::OnCommand(WPARAM wParam, LPARAM lParam)
     // TODO: 在此添加专用代码和/或调用基类
     WORD command = LOWORD(wParam);
 
-    if (command == ID_PLAYLIST_SELECT_ALL)             // 处理播放列表ctrl+A触发的全选命令
+    if (command == ID_PLAYLIST_SELECT_CHANGE)       // 更新播放列表选中项
     {
-        m_playlist_ctrl.SelectAll();
         GetPlaylistItemSelected();
         return true;
     }

--- a/MusicPlayer2/MiniModeDlg.cpp
+++ b/MusicPlayer2/MiniModeDlg.cpp
@@ -333,6 +333,12 @@ void CMiniModeDlg::SetDragEnable()
     m_playlist_ctrl.SetDragEnable(CPlayer::GetInstance().IsPlaylistMode() && !theApp.m_media_lib_setting_data.disable_drag_sort);
 }
 
+void CMiniModeDlg::GetPlaylistItemSelected()
+{
+    m_item_selected = m_playlist_ctrl.GetCurSel();          // 获取鼠标选中的项目
+    m_playlist_ctrl.GetItemSelected(m_items_selected);      // 获取多个选中的项目
+}
+
 void CMiniModeDlg::DrawInfo()
 {
     if (!IsIconic() && IsWindowVisible())		//窗口最小化或隐藏时不绘制，以降低CPU利用率
@@ -635,6 +641,13 @@ BOOL CMiniModeDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 {
     // TODO: 在此添加专用代码和/或调用基类
     WORD command = LOWORD(wParam);
+
+    if (command == ID_PLAYLIST_SELECT_ALL)             // 处理播放列表ctrl+A触发的全选命令
+    {
+        m_playlist_ctrl.SelectAll();
+        GetPlaylistItemSelected();
+        return true;
+    }
     if ((command >= ID_ADD_TO_DEFAULT_PLAYLIST && command <= ID_ADD_TO_MY_FAVOURITE + ADD_TO_PLAYLIST_MAX_SIZE)
         || command == ID_ADD_TO_OTHER_PLAYLIST)
     {

--- a/MusicPlayer2/MiniModeDlg.h
+++ b/MusicPlayer2/MiniModeDlg.h
@@ -35,6 +35,8 @@ public:
     void SetDragEnable();
     CPlayListCtrl& GetPlaylistCtrl() { return m_playlist_ctrl; }
 
+    void GetPlaylistItemSelected();
+
     void DrawInfo();
 
 protected:

--- a/MusicPlayer2/MusicPlayerCmdHelper.cpp
+++ b/MusicPlayer2/MusicPlayerCmdHelper.cpp
@@ -110,7 +110,7 @@ bool CMusicPlayerCmdHelper::OnAddToNewPlaylist(std::function<void(std::vector<So
         playlist.SaveToFile(playlist_path);
         theApp.m_pMainWnd->SendMessage(WM_INIT_ADD_TO_MENU);
 
-        RefreshMediaTabData(1);
+        RefreshMediaTabData(ML_PLAYLIST);
 
         return true;
     }
@@ -595,14 +595,14 @@ void CMusicPlayerCmdHelper::ShowMediaLib(int cur_tab /*= -1*/, int tab_force_sho
     }
 }
 
-void CMusicPlayerCmdHelper::RefreshMediaTabData(int tab_index)
+void CMusicPlayerCmdHelper::RefreshMediaTabData(enum eMediaLibTab tab_index)
 {
     CMusicPlayerDlg* pPlayerDlg = dynamic_cast<CMusicPlayerDlg*>(theApp.m_pMainWnd);
     if (pPlayerDlg != nullptr && pPlayerDlg->m_pMediaLibDlg != nullptr && IsWindow(pPlayerDlg->m_pMediaLibDlg->GetSafeHwnd()))
     {
-        if (tab_index == 0)
+        if (tab_index == ML_FOLDER)
             pPlayerDlg->m_pMediaLibDlg->m_path_dlg.RefreshTabData();         // 刷新媒体库文件夹列表
-        else if(tab_index == 1)
+        else if(tab_index == ML_PLAYLIST)
             pPlayerDlg->m_pMediaLibDlg->m_playlist_dlg.RefreshSongList();    // 刷新媒体库播放列表列表
     }
 }

--- a/MusicPlayer2/MusicPlayerCmdHelper.cpp
+++ b/MusicPlayer2/MusicPlayerCmdHelper.cpp
@@ -112,7 +112,7 @@ bool CMusicPlayerCmdHelper::OnAddToNewPlaylist(std::function<void(std::vector<So
 
         if (pPlayerDlg != nullptr && pPlayerDlg->m_pMediaLibDlg != nullptr && IsWindow(pPlayerDlg->m_pMediaLibDlg->GetSafeHwnd()))
         {
-            pPlayerDlg->m_pMediaLibDlg->m_playlist_dlg.SetUpdateFlag();		//设置数据刷新标志
+            pPlayerDlg->m_pMediaLibDlg->m_playlist_dlg.RefreshSongList();   // 刷新播放列表列表
         }
 
         return true;
@@ -595,6 +595,18 @@ void CMusicPlayerCmdHelper::ShowMediaLib(int cur_tab /*= -1*/, int tab_force_sho
         pPlayerDlg->m_pMediaLibDlg->SetTabForceShow(tab_force_show);
         pPlayerDlg->m_pMediaLibDlg->Create(IDD_MEDIA_LIB_DIALOG/*, GetDesktopWindow()*/);
         pPlayerDlg->m_pMediaLibDlg->ShowWindow(SW_SHOW);
+    }
+}
+
+void CMusicPlayerCmdHelper::RefreshMediaTabData(int tab_index)
+{
+    CMusicPlayerDlg* pPlayerDlg = dynamic_cast<CMusicPlayerDlg*>(theApp.m_pMainWnd);
+    if (pPlayerDlg != nullptr && pPlayerDlg->m_pMediaLibDlg != nullptr && IsWindow(pPlayerDlg->m_pMediaLibDlg->GetSafeHwnd()))
+    {
+        if (tab_index == 0)
+            pPlayerDlg->m_pMediaLibDlg->m_path_dlg.RefreshTabData();         // 刷新媒体库文件夹列表
+        else if(tab_index == 1)
+            pPlayerDlg->m_pMediaLibDlg->m_playlist_dlg.RefreshSongList();    // 刷新媒体库播放列表列表
     }
 }
 

--- a/MusicPlayer2/MusicPlayerCmdHelper.cpp
+++ b/MusicPlayer2/MusicPlayerCmdHelper.cpp
@@ -110,10 +110,7 @@ bool CMusicPlayerCmdHelper::OnAddToNewPlaylist(std::function<void(std::vector<So
         playlist.SaveToFile(playlist_path);
         theApp.m_pMainWnd->SendMessage(WM_INIT_ADD_TO_MENU);
 
-        if (pPlayerDlg != nullptr && pPlayerDlg->m_pMediaLibDlg != nullptr && IsWindow(pPlayerDlg->m_pMediaLibDlg->GetSafeHwnd()))
-        {
-            pPlayerDlg->m_pMediaLibDlg->m_playlist_dlg.RefreshSongList();   // 刷新播放列表列表
-        }
+        RefreshMediaTabData(1);
 
         return true;
     }

--- a/MusicPlayer2/MusicPlayerCmdHelper.h
+++ b/MusicPlayer2/MusicPlayerCmdHelper.h
@@ -56,7 +56,7 @@ public:
     void ShowMediaLib(int cur_tab = -1, int tab_force_show = 0);
 
     //刷新媒体库指定标签页，0刷新文件夹，1刷新播放列表
-    static void RefreshMediaTabData(int tab_index);
+    static void RefreshMediaTabData(enum eMediaLibTab tab);
 
     //查看艺术家
     void OnViewArtist(const SongInfo& song_info);

--- a/MusicPlayer2/MusicPlayerCmdHelper.h
+++ b/MusicPlayer2/MusicPlayerCmdHelper.h
@@ -55,6 +55,9 @@ public:
     //tab_force_show: 要强制显示的标签，使用int中的各个bit表示要显示的标签，每个bit参见枚举 MediaLibDisplayItem 的声明
     void ShowMediaLib(int cur_tab = -1, int tab_force_show = 0);
 
+    //刷新媒体库指定标签页，0刷新文件夹，1刷新播放列表
+    static void RefreshMediaTabData(int tab_index);
+
     //查看艺术家
     void OnViewArtist(const SongInfo& song_info);
 

--- a/MusicPlayer2/MusicPlayerDlg.cpp
+++ b/MusicPlayer2/MusicPlayerDlg.cpp
@@ -230,6 +230,7 @@ BEGIN_MESSAGE_MAP(CMusicPlayerDlg, CMainDialogBase)
     ON_COMMAND(ID_CLOSE_DESKTOP_LYRIC, &CMusicPlayerDlg::OnCloseDesktopLyric)
     ON_COMMAND(ID_LYRIC_DISPLAYED_DOUBLE_LINE, &CMusicPlayerDlg::OnLyricDisplayedDoubleLine)
     ON_COMMAND(ID_LYRIC_BACKGROUND_PENETRATE, &CMusicPlayerDlg::OnLyricBackgroundPenetrate)
+    ON_COMMAND(ID_PLAYLIST_SELECT_CHANGE, &CMusicPlayerDlg::OnPlaylistSelectChange)
     ON_COMMAND(ID_PLAYLIST_SELECT_ALL, &CMusicPlayerDlg::OnPlaylistSelectAll)
     ON_COMMAND(ID_PLAYLIST_SELECT_NONE, &CMusicPlayerDlg::OnPlaylistSelectNone)
     ON_COMMAND(ID_PLAYLIST_SELECT_REVERT, &CMusicPlayerDlg::OnPlaylistSelectRevert)
@@ -5000,6 +5001,13 @@ void CMusicPlayerDlg::OnLyricBackgroundPenetrate()
     // TODO: 在此添加命令处理程序代码
     theApp.m_lyric_setting_data.desktop_lyric_data.lyric_background_penetrate = !theApp.m_lyric_setting_data.desktop_lyric_data.lyric_background_penetrate;
     m_desktop_lyric.SetLyricBackgroundPenetrate(theApp.m_lyric_setting_data.desktop_lyric_data.lyric_background_penetrate);
+}
+
+
+void CMusicPlayerDlg::OnPlaylistSelectChange()
+{
+    // TODO: 在此添加命令处理程序代码
+    GetPlaylistItemSelected();
 }
 
 

--- a/MusicPlayer2/MusicPlayerDlg.cpp
+++ b/MusicPlayer2/MusicPlayerDlg.cpp
@@ -2549,7 +2549,8 @@ void CMusicPlayerDlg::OnFileOpen()
         CPlayer::GetInstance().OpenFiles(files);
         UpdatePlayPauseButton();
         DrawInfo(true);
-        CMusicPlayerCmdHelper::RefreshMediaTabData(1);
+        // 打开文件时刷新媒体库播放列表标签
+        CMusicPlayerCmdHelper::RefreshMediaTabData(CMusicPlayerCmdHelper::ML_PLAYLIST);
         m_play_error_cnt = 0;
     }
 }
@@ -2580,7 +2581,8 @@ void CMusicPlayerDlg::OnFileOpenFolder()
         UpdatePlayPauseButton();
         //SetPorgressBarSize();
         DrawInfo(true);
-        CMusicPlayerCmdHelper::RefreshMediaTabData(0);
+        // 打开文件夹时刷新
+        CMusicPlayerCmdHelper::RefreshMediaTabData(CMusicPlayerCmdHelper::ML_FOLDER);
         m_play_error_cnt = 0;
     }
 }
@@ -2600,12 +2602,12 @@ void CMusicPlayerDlg::OnDropFiles(HDROP hDropInfo)
     {
         //file_path_wcs.push_back(L'\\');
         CPlayer::GetInstance().OpenFolder(file_path_wcs);
-        CMusicPlayerCmdHelper::RefreshMediaTabData(0);
+        CMusicPlayerCmdHelper::RefreshMediaTabData(CMusicPlayerCmdHelper::ML_FOLDER);
     }
     else if (CPlaylistFile::IsPlaylistFile(file_path_wcs))
     {
         CPlayer::GetInstance().OpenPlaylistFile(file_path_wcs);
-        CMusicPlayerCmdHelper::RefreshMediaTabData(1);
+        CMusicPlayerCmdHelper::RefreshMediaTabData(CMusicPlayerCmdHelper::ML_PLAYLIST);
     }
     else
     {
@@ -2625,7 +2627,7 @@ void CMusicPlayerDlg::OnDropFiles(HDROP hDropInfo)
             else
             {
                 CPlayer::GetInstance().OpenFiles(files, false);
-                CMusicPlayerCmdHelper::RefreshMediaTabData(1);
+                CMusicPlayerCmdHelper::RefreshMediaTabData(CMusicPlayerCmdHelper::ML_PLAYLIST);
             }
         }
     }
@@ -2804,7 +2806,7 @@ void CMusicPlayerDlg::OnReloadPlaylist()
 {
     // TODO: 在此添加命令处理程序代码
     CPlayer::GetInstance().ReloadPlaylist();
-    CMusicPlayerCmdHelper::RefreshMediaTabData(1);
+    CMusicPlayerCmdHelper::RefreshMediaTabData(CMusicPlayerCmdHelper::ML_PLAYLIST);
     //ShowPlayList();
     //UpdatePlayPauseButton();
     //ShowTime();

--- a/MusicPlayer2/MusicPlayerDlg.cpp
+++ b/MusicPlayer2/MusicPlayerDlg.cpp
@@ -2548,6 +2548,7 @@ void CMusicPlayerDlg::OnFileOpen()
         CPlayer::GetInstance().OpenFiles(files);
         UpdatePlayPauseButton();
         DrawInfo(true);
+        CMusicPlayerCmdHelper::RefreshMediaTabData(1);
         m_play_error_cnt = 0;
     }
 }
@@ -2578,6 +2579,7 @@ void CMusicPlayerDlg::OnFileOpenFolder()
         UpdatePlayPauseButton();
         //SetPorgressBarSize();
         DrawInfo(true);
+        CMusicPlayerCmdHelper::RefreshMediaTabData(0);
         m_play_error_cnt = 0;
     }
 }
@@ -2597,10 +2599,12 @@ void CMusicPlayerDlg::OnDropFiles(HDROP hDropInfo)
     {
         //file_path_wcs.push_back(L'\\');
         CPlayer::GetInstance().OpenFolder(file_path_wcs);
+        CMusicPlayerCmdHelper::RefreshMediaTabData(0);
     }
     else if (CPlaylistFile::IsPlaylistFile(file_path_wcs))
     {
         CPlayer::GetInstance().OpenPlaylistFile(file_path_wcs);
+        CMusicPlayerCmdHelper::RefreshMediaTabData(1);
     }
     else
     {
@@ -2620,6 +2624,7 @@ void CMusicPlayerDlg::OnDropFiles(HDROP hDropInfo)
             else
             {
                 CPlayer::GetInstance().OpenFiles(files, false);
+                CMusicPlayerCmdHelper::RefreshMediaTabData(1);
             }
         }
     }
@@ -2798,6 +2803,7 @@ void CMusicPlayerDlg::OnReloadPlaylist()
 {
     // TODO: 在此添加命令处理程序代码
     CPlayer::GetInstance().ReloadPlaylist();
+    CMusicPlayerCmdHelper::RefreshMediaTabData(1);
     //ShowPlayList();
     //UpdatePlayPauseButton();
     //ShowTime();

--- a/MusicPlayer2/MusicPlayerDlg.h
+++ b/MusicPlayer2/MusicPlayerDlg.h
@@ -390,6 +390,7 @@ public:
     afx_msg void OnCloseDesktopLyric();
     afx_msg void OnLyricDisplayedDoubleLine();
     afx_msg void OnLyricBackgroundPenetrate();
+    afx_msg void OnPlaylistSelectChange();
     afx_msg void OnPlaylistSelectAll();
     afx_msg void OnPlaylistSelectNone();
     afx_msg void OnPlaylistSelectRevert();

--- a/MusicPlayer2/SetPathDlg.cpp
+++ b/MusicPlayer2/SetPathDlg.cpp
@@ -40,6 +40,12 @@ void CSetPathDlg::AdjustColumnWidth()
         m_path_list.SetColumnWidth(i, width[i]);
 }
 
+void CSetPathDlg::RefreshTabData()
+{
+    ShowPathList();
+    SetButtonsEnable(IsSelectedPlayEnable());
+}
+
 void CSetPathDlg::ShowPathList()
 {
 	m_path_list.EnableWindow(TRUE);

--- a/MusicPlayer2/SetPathDlg.h
+++ b/MusicPlayer2/SetPathDlg.h
@@ -25,7 +25,8 @@ public:
 
 public:
 	void QuickSearch(const wstring& key_words);		//根据关键字执行快速查找m_search_result中
-    void AdjustColumnWidth();       //自动调整列表宽度
+    void AdjustColumnWidth();                       //自动调整列表宽度
+    void RefreshTabData();                          //刷新标签页数据
 
 protected:
 	deque<PathInfo>& m_recent_path;		//最近打开过的路径

--- a/MusicPlayer2/resource.h
+++ b/MusicPlayer2/resource.h
@@ -1457,13 +1457,14 @@
 #define ID_USE_STANDARD_TITLE_BAR       33339
 #define ID_PLAYLIST_VIEW_ARTIST         33340
 #define ID_PLAYLIST_VIEW_ALBUM          33341
+#define ID_PLAYLIST_SELECT_CHANGE       33342
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        541
-#define _APS_NEXT_COMMAND_VALUE         33342
+#define _APS_NEXT_COMMAND_VALUE         33343
 #define _APS_NEXT_CONTROL_VALUE         1186
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
播放一首歌的动作应当是主窗口做，因为需要同步到不同的播放列表。
从浮动播放列表复制代码补上。
解决不会同步以及mini播放列表连续双击播放时的显示