### PR TITLE
添加UincodeToStr的UTF16BE支持，歌词保存修正

### DIFF
--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -387,7 +387,7 @@ wstring CCommon::StrToUnicode(const string& str, CodeType code_type, bool auto_u
 			temp.pop_back();
 		temp.push_back('\0');
 		wchar_t* p = (wchar_t*)temp.c_str();
-		convertBEtoLE(p, temp.size() >> 1);
+		convertBE_LE(p, temp.size() >> 1);
 		result = p;
 		result_ready = true;
 	}
@@ -444,6 +444,17 @@ string CCommon::UnicodeToStr(const wstring & wstr, CodeType code_type, bool* cha
 		result.push_back(-1);	//在前面加上UTF16LE的BOM
 		result.push_back(-2);
 		result.append((const char*)wstr.c_str(), (const char*)wstr.c_str() + wstr.size() * 2);
+		result.push_back('\0');
+	}
+	else if (code_type == CodeType::UTF16BE)
+	{
+		result.clear();
+		result.push_back(-2);	//在前面加上UTF16BE的BOM
+		result.push_back(-1);
+		wchar_t* p = (wchar_t*)wstr.c_str();
+		convertBE_LE(p, wstr.size());
+		wstring temp{ p };
+		result.append((const char*)temp.c_str(), (const char*)temp.c_str() + temp.size() * 2);
 		result.push_back('\0');
 	}
 	if (char_cannot_convert != nullptr)

--- a/MusicPlayer2/Common.h
+++ b/MusicPlayer2/Common.h
@@ -148,8 +148,8 @@ public:
 	//将string类型的字符串转换成Unicode编码的wstring字符串
 	static wstring StrToUnicode(const string& str, CodeType code_type = CodeType::AUTO, bool auto_utf8 = false);
 
-	//将UTF16BE转换为UTF16LE
-	static inline void convertBEtoLE(wchar_t* bigEndianBuffer, unsigned int length)
+	//进行UTF16的BE、LE之间的转换
+	static inline void convertBE_LE(wchar_t* bigEndianBuffer, unsigned int length)
 	{
 		for (unsigned int i = 0; i < length; ++i)
 		{
@@ -161,6 +161,10 @@ public:
 	}
 
 	//将Unicode编码的wstring字符串转换成string类型的字符串，如果有字符无法转换，将参数char_cannot_convert指向的bool变量置为true
+	//当有可能转换带有BOM的类型时需注意
+	//UTF8若自行处理BOM可使用UTF8_NO_BOM分段处理否则请一次转换
+	//UTF16LE请一次转换，或不使用此方法并自行处理BOM
+	//UTF16BE请一次转换，特别的，自行处理需注意大小端问题
 	static string UnicodeToStr(const wstring & wstr, CodeType code_type, bool* char_cannot_convert = nullptr);
 
 	//将一个只有ASCII码组成的字符串转换成Unicode

--- a/MusicPlayer2/Lyric.cpp
+++ b/MusicPlayer2/Lyric.cpp
@@ -412,67 +412,42 @@ wstring CLyrics::GetLyricsString2() const
 void CLyrics::SaveLyric()
 {
     if (m_lyrics.size() == 0) return;	//没有歌词时直接返回
-    ofstream out_put{ m_file };
-    //如果歌词编码是UTF8，先在前面输出BOM
-    if (m_code_type == CodeType::UTF8)
-    {
-        char buff[4];
-        buff[0] = -17;
-        buff[1] = -69;
-        buff[2] = -65;
-        buff[3] = 0;
-        out_put << buff;
-    }
+
+    // 保存歌词到文件，偏移量保存在offset标签
+    wstring temp{};
     for (int i{ 0 }; i < static_cast<int>(m_lyrics_str.size()); i++)
     {
         if (m_offset_tag_index == i)	//如果i是偏移标签的位置，则在这时输出偏移标签
         {
-            out_put << "[offset:" << m_offset << ']' << std::endl;
+            temp += L"[offset:" + std::to_wstring(m_offset) + L"]\r\n";
             if (!m_offset_tag)			//如果本来没有偏移标签，则这时是插入一行偏移标签，之后还要输出当前歌词
-                out_put << CCommon::UnicodeToStr(m_lyrics_str[i], m_code_type) << std::endl;
+                temp += m_lyrics_str[i] + L"\r\n";
         }
         else
         {
-            out_put << CCommon::UnicodeToStr(m_lyrics_str[i], m_code_type) << std::endl;
+            temp += m_lyrics_str[i] + L"\r\n";
         }
     }
+    bool char_connot_convert;
+    string lyric_str = CCommon::UnicodeToStr(temp, m_code_type, &char_connot_convert);
+    ASSERT(!char_connot_convert);
+    ofstream out_put{ m_file, std::ios::binary };
+    out_put << lyric_str;
+    out_put.close();
+
     m_modified = false;
 }
 
 void CLyrics::SaveLyric2()
 {
     if (m_lyrics.size() == 0) return;	//没有歌词时直接返回
-    ofstream out_put{ m_file };
-    //如果歌词编码是UTF8，先在前面输出BOM
-    if (m_code_type == CodeType::UTF8)
-    {
-        char buff[4];
-        buff[0] = -17;
-        buff[1] = -69;
-        buff[2] = -65;
-        buff[3] = 0;
-        out_put << buff;
-    }
-    //输出标识标签
-    CodeType text_code_type{ m_code_type };
-    if (text_code_type == CodeType::UTF8)
-        text_code_type = CodeType::UTF8_NO_BOM;
-    if(m_id_tag) out_put << "[id:" << CCommon::UnicodeToStr(m_id, text_code_type) << "]" << std::endl;
-    if(m_ti_tag) out_put << "[ti:" << CCommon::UnicodeToStr(m_ti, text_code_type) << "]" << std::endl;
-    if (m_ar_tag) out_put << "[ar:" << CCommon::UnicodeToStr(m_ar, text_code_type) << "]" << std::endl;
-    if (m_al_tag) out_put << "[al:" << CCommon::UnicodeToStr(m_al, text_code_type) << "]" << std::endl;
-    if (m_by_tag) out_put << "[by:" << CCommon::UnicodeToStr(m_by, text_code_type) << "]" << std::endl;
-    if (m_offset_tag) out_put << "[offset:0]" << std::endl;		//由于偏移量被保存到时间标签中，所以offset标签中的偏移量为0
-    char time_buff[16];
-    for (auto a_lyric : m_lyrics)
-    {
-        Time a_time{ a_lyric.GetTime(m_offset) };
-        sprintf_s(time_buff, "[%.2d:%.2d.%.2d]", a_time.min, a_time.sec, a_time.msec / 10);
-        out_put << time_buff << CCommon::UnicodeToStr(a_lyric.text, text_code_type);
-        if (!a_lyric.translate.empty())
-            out_put << " / " << CCommon::UnicodeToStr(a_lyric.translate, text_code_type);
-        out_put << std::endl;
-    }
+
+    // 保存歌词到文件，将偏移量存入每个时间标签
+    bool char_connot_convert;
+    string lyric_str = CCommon::UnicodeToStr(GetLyricsString2(), m_code_type, &char_connot_convert);
+    ASSERT(!char_connot_convert);
+    ofstream out_put{ m_file, std::ios::binary };
+    out_put << lyric_str;
     out_put.close();
     m_modified = false;
     m_chinese_converted = false;

--- a/MusicPlayer2/LyricEditDlg.cpp
+++ b/MusicPlayer2/LyricEditDlg.cpp
@@ -135,8 +135,7 @@ bool CLyricEditDlg::SaveLyric(wstring path, CodeType code_type)
 	    string lyric_str = CCommon::UnicodeToStr(m_lyric_string, code_type, &char_connot_convert);
 	    if (char_connot_convert)	//当文件中包含Unicode字符时，询问用户是否要选择一个Unicode编码格式再保存
 	    {
-		    CString info;
-		    info.LoadString(IDS_STRING103);		//从string table载入字符串
+            CString info{ CCommon::LoadText(IDS_STRING103) };                                   //从string table载入字符串
 		    if (MessageBox(info, NULL, MB_OKCANCEL | MB_ICONWARNING) != IDOK) return false;		//如果用户点击了取消按钮，则返回false
 	    }
 	    ofstream out_put{ path, std::ios::binary };


### PR DESCRIPTION
CLyrics类的SaveLyric与SaveLyric2方法最初好像只用来保存偏移量，当时也没有UTF16支持，是个遗留问题。

SaveLyric是靠一个没有gui的设置启用的偏移量保存，应该没有UincodeToStr转换失败的情况。
SaveLyric2除了保存偏移量外还用来保存涉及字符编辑的繁简转换，此处不知道有没有可能出现转换失败。
其他位置都写了自己的SaveLyric方法，有足够的异常处理。