### PR TITLE
歌词解析翻译相关

### DIFF
--- a/MusicPlayer2/Lyric.cpp
+++ b/MusicPlayer2/Lyric.cpp
@@ -215,12 +215,7 @@ void CLyrics::ParseLyricText(const wstring& lyric_text_ori, wstring& lyric_text,
         lyric_translate = lyric_text_ori.substr(index1 + 3);
         lyric_text = lyric_text_ori.substr(0, index1);
     }
-    //按带括号的翻译格式解析，如果都失败，则认为没有翻译
-    else if (!ParseLyricTextWithBracket(lyric_text_ori, lyric_text, lyric_translate, L'【', L'】')//【】
-        && !ParseLyricTextWithBracket(lyric_text_ori, lyric_text, lyric_translate, L'〖', L'〗')//〖〗
-        && !ParseLyricTextWithBracket(lyric_text_ori, lyric_text, lyric_translate, L'「', L'」')//「」
-        && !ParseLyricTextWithBracket(lyric_text_ori, lyric_text, lyric_translate, L'『', L'』')//『』
-        )
+    else
     {
         lyric_text = lyric_text_ori;
         lyric_translate.clear();
@@ -528,6 +523,30 @@ void CLyrics::TimeTagDelay()
     for (size_t i{ m_lyrics.size() - 1 }; i > 0; i--)
     {
         m_lyrics[i].time = m_lyrics[i - 1].time;
+    }
+}
+
+void CLyrics::ExtractTranslationFromBrackets()
+{
+    // 若对已有翻译的歌词使用则放弃原翻译
+    m_translate = false;
+    for (Lyric lyric : m_lyrics)
+    {
+        wstring temp = lyric.text;
+        //按带括号的翻译格式解析
+        if (   ParseLyricTextWithBracket(temp, lyric.text, lyric.translate, L'【', L'】')//【】
+            || ParseLyricTextWithBracket(temp, lyric.text, lyric.translate, L'〖', L'〗')//〖〗
+            || ParseLyricTextWithBracket(temp, lyric.text, lyric.translate, L'「', L'」')//「」
+            || ParseLyricTextWithBracket(temp, lyric.text, lyric.translate, L'『', L'』')//『』
+            )
+        {
+            m_translate = true;
+        }
+        else
+        {
+            lyric.text = temp;
+            lyric.translate.clear();
+        }
     }
 }
 

--- a/MusicPlayer2/Lyric.h
+++ b/MusicPlayer2/Lyric.h
@@ -89,6 +89,8 @@ public:
     void SwapTextAndTranslation();      //交换歌词文本和翻译
     void TimeTagForward();          //时间标签提前一句
     void TimeTagDelay();            //时间标签延后一句
+	// 从歌词原文的括号中提取翻译，丢弃原有翻译
+	void ExtractTranslationFromBrackets();
 
 	void AdjustLyric(int offset);	//调整歌词的偏移量
 


### PR DESCRIPTION
https://github.com/zhongyang219/MusicPlayer2/commit/ef6b52125ce0dea52de80dc448fef6d9f3cc1791#commitcomment-53012193

这里识别括号出错太多，歌词里各种括号的用法全部适应不太可能。
重灾区是下载歌词时，平时播放也有部分错误。

```lrc
[00:00.00]作曲 : 折户伸智 / 作词 : Key
[00:00.00]『鸟の诗』
[00:05.00]「AIR」
[00:07.00]歌 ：Lia
[00:09.00]作词：Key

[00:00.25]quantum jump
[00:03.25]PCゲーム「フレラバ ～Friend to Lover～」OP
[00:07.25]
```

以及<https://music.163.com/#/album?id=34893357>这样的。

我觉得这个功能原意是对一些将原文以及加括号的翻译一起写在原文中的歌词的解析。暂时取消