### PR TITLE
桌面歌词空行处理设置

### DIFF
--- a/MusicPlayer2/CommonData.h
+++ b/MusicPlayer2/CommonData.h
@@ -183,6 +183,7 @@ struct DesktopLyricSettingData		//桌面歌词设置
     bool lyric_background_penetrate{ false };
     bool show_unlock_when_locked{ true };           //桌面歌词锁定时显示解锁图标
     Alignment lyric_align{ Alignment::CENTER }; //歌词的对齐方式
+    bool display_void_line{ true };                 //将空行显示为独立的一行（Music...）
 };
 
 struct LyricSettingData

--- a/MusicPlayer2/DesktopLyric.cpp
+++ b/MusicPlayer2/DesktopLyric.cpp
@@ -96,7 +96,7 @@ void CDesktopLyric::ShowLyric()
         Time time{ CPlayer::GetInstance().GetCurrentPosition() };
         CLyrics::Lyric lyric = now_lyrics.GetLyric(time, 0);
         bool is_lyric_empty{ lyric.text.empty() };
-        bool is_updated{ false };
+        int lyric_mode{};
         int lyric_index = now_lyrics.GetLyricIndex(time);
         int progress = now_lyrics.GetLyricProgress(time);
         if (theApp.m_lyric_setting_data.desktop_lyric_data.display_void_line)  // 设置为独立显示空行
@@ -119,22 +119,15 @@ void CDesktopLyric::ShowLyric()
                     if (blanktimeok)
                     {
                         // progress = now_lyrics.GetLyricProgressIgnoreBlank(time); // 获取合并空白行后的进度
-                        UpdateLyrics(L"♪♪♪", lyric.text.c_str(), progress, true);
-                        is_updated = true;
+                        lyric_mode = 1;
                     }
                     else
                         progress = 0;
                 }
                 else if (blanktimeok)                                          // 当前time对应非空歌词但是上行歌词为空
-                {
-                    UpdateLyrics(L"♪♪♪", lyric.text.c_str(), progress, false);
-                    is_updated = true;
-                }
+                    lyric_mode = 2;
             }
         }
-        if (!is_updated)
-            UpdateLyrics(lyric.text.c_str(), progress);
-        UpdateLyricTranslate(lyric.translate.c_str());
 
         SetLyricDoubleLine(theApp.m_lyric_setting_data.desktop_lyric_data.lyric_double_line);
         SetShowTranslate(theApp.m_ui_data.show_translate);
@@ -171,6 +164,14 @@ void CDesktopLyric::ShowLyric()
 		{
             SetLyricChangeFlag(false);
 		}
+        UpdateLyricTranslate(lyric.translate.c_str());
+        // UpdateLyrics需要放在最后防止双行歌词闪烁
+        if (lyric_mode == 1)
+            UpdateLyrics(L"♪♪♪", lyric.text.c_str(), progress, true);
+        else if (lyric_mode == 2)
+            UpdateLyrics(L"♪♪♪", lyric.text.c_str(), progress, false);
+        else
+            UpdateLyrics(lyric.text.c_str(), progress);
 	}
 	else
 	{

--- a/MusicPlayer2/DesktopLyric.cpp
+++ b/MusicPlayer2/DesktopLyric.cpp
@@ -92,27 +92,26 @@ void CDesktopLyric::ShowLyric()
 	}
 	else if (!CPlayer::GetInstance().m_Lyrics.IsEmpty())
 	{
-        bool ignore_space{ true };
 		Time time{ CPlayer::GetInstance().GetCurrentPosition() };
         int lyric_index = CPlayer::GetInstance().m_Lyrics.GetLyricIndex(time);
 		int progress = CPlayer::GetInstance().m_Lyrics.GetLyricProgress(time);
 		CLyrics::Lyric lyric = CPlayer::GetInstance().m_Lyrics.GetLyric(time, 0);
         if (lyric.text.empty())
         {
-            if (ignore_space)
+            if (theApp.m_lyric_setting_data.desktop_lyric_data.display_void_line)
             {
-                lyric = CPlayer::GetInstance().m_Lyrics.GetLyricIgnoreSpace(time, 0);
+                lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
+            }
+            else
+            {
+                lyric = CPlayer::GetInstance().m_Lyrics.GetLyricIgnoreVoid(time, 0);
                 if (lyric.text.empty())
                     lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
                 else
                 {
                     progress = 0;  // 通过忽略空白得到的歌词还没到显示的时间，清0进度
-                    lyric_index = CPlayer::GetInstance().m_Lyrics.GetLyricIndexIgnoreSpace(time);
+                    lyric_index = CPlayer::GetInstance().m_Lyrics.GetLyricIndexIgnoreVoid(time);
                 }
-            }
-            else
-            {
-                lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
             }
         }
 
@@ -122,11 +121,11 @@ void CDesktopLyric::ShowLyric()
         SetLyricKaraokeDisplay(theApp.m_lyric_setting_data.lyric_karaoke_disp);
         if(theApp.m_lyric_setting_data.desktop_lyric_data.lyric_double_line)
         {
-            CLyrics::Lyric next_lyric = CPlayer::GetInstance().m_Lyrics.GetLyric(time, 1);
-            if (ignore_space)
-            {
-                next_lyric = CPlayer::GetInstance().m_Lyrics.GetLyricIgnoreSpace(time, 1);
-            }
+            CLyrics::Lyric next_lyric;
+            if (theApp.m_lyric_setting_data.desktop_lyric_data.display_void_line)
+                next_lyric = CPlayer::GetInstance().m_Lyrics.GetLyric(time, 1);
+            else
+                next_lyric = CPlayer::GetInstance().m_Lyrics.GetLyricIgnoreVoid(time, 1);
             if (next_lyric.text.empty())
                 next_lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
             SetNextLyric(next_lyric.text.c_str());

--- a/MusicPlayer2/DesktopLyric.cpp
+++ b/MusicPlayer2/DesktopLyric.cpp
@@ -92,11 +92,29 @@ void CDesktopLyric::ShowLyric()
 	}
 	else if (!CPlayer::GetInstance().m_Lyrics.IsEmpty())
 	{
+        bool ignore_space{ true };
 		Time time{ CPlayer::GetInstance().GetCurrentPosition() };
+        int lyric_index = CPlayer::GetInstance().m_Lyrics.GetLyricIndex(time);
 		int progress = CPlayer::GetInstance().m_Lyrics.GetLyricProgress(time);
 		CLyrics::Lyric lyric = CPlayer::GetInstance().m_Lyrics.GetLyric(time, 0);
-		if (lyric.text.empty())
-			lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
+        if (lyric.text.empty())
+        {
+            if (ignore_space)
+            {
+                lyric = CPlayer::GetInstance().m_Lyrics.GetLyricIgnoreSpace(time, 0);
+                if (lyric.text.empty())
+                    lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
+                else
+                {
+                    progress = 0;  // 通过忽略空白得到的歌词还没到显示的时间，清0进度
+                    lyric_index = CPlayer::GetInstance().m_Lyrics.GetLyricIndexIgnoreSpace(time);
+                }
+            }
+            else
+            {
+                lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
+            }
+        }
 
         SetLyricDoubleLine(theApp.m_lyric_setting_data.desktop_lyric_data.lyric_double_line);
         SetShowTranslate(theApp.m_ui_data.show_translate);
@@ -105,12 +123,15 @@ void CDesktopLyric::ShowLyric()
         if(theApp.m_lyric_setting_data.desktop_lyric_data.lyric_double_line)
         {
             CLyrics::Lyric next_lyric = CPlayer::GetInstance().m_Lyrics.GetLyric(time, 1);
+            if (ignore_space)
+            {
+                next_lyric = CPlayer::GetInstance().m_Lyrics.GetLyricIgnoreSpace(time, 1);
+            }
             if (next_lyric.text.empty())
                 next_lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
             SetNextLyric(next_lyric.text.c_str());
         }
 
-        int lyric_index = CPlayer::GetInstance().m_Lyrics.GetLyricIndex(time);
         static int last_lyric_index = -1;
 
 		if (lyric_index != last_lyric_index)

--- a/MusicPlayer2/DesktopLyric.cpp
+++ b/MusicPlayer2/DesktopLyric.cpp
@@ -106,19 +106,19 @@ void CDesktopLyric::ShowLyric()
         }
         else
         {
+            lyric_index = now_lyrics.GetLyricIndexIgnoreBlank(lyric_index, 0); // 使用忽略空白行后的索引
             if (is_lyric_empty)                                                // 如果当前time对应歌词为空则试着忽略空白获取歌词
-                lyric = now_lyrics.GetLyricIgnoreVoid(time, 0);
+                lyric = now_lyrics.GetLyricIgnoreBlank(lyric_index);
             if (lyric.text.empty())                                            // 如果忽略空白仍然不能取得歌词说明时间已超过末尾的歌词
                 lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
             else
             {
-                lyric_index = now_lyrics.GetLyricIndexIgnoreVoid(time, 0);     // 使用忽略空白行后的索引
-                bool blanktimeok{ now_lyrics.GetBlankTimeBeforeLyric(time, 0) > 1000 }; // 判断空白时长是否有必要显示符号
+                bool blanktimeok{ now_lyrics.GetBlankTimeBeforeLyric(lyric_index) > 800 };   // 判断空白时长是否有必要显示符号
                 if (is_lyric_empty)                                            // 当前time处在空白行中并且正在提前显示下一行歌词
                 {
                     if (blanktimeok)
                     {
-                        // progress = now_lyrics.GetLyricProgressIgnoreBlank(time); // 获取合并空白行后的进度
+                        progress = now_lyrics.GetBlankLyricProgress(lyric_index, time);      // 获取合并空白行后的进度
                         lyric_mode = 1;
                     }
                     else
@@ -144,10 +144,11 @@ void CDesktopLyric::ShowLyric()
             }
             else
             {
-                next_lyric = now_lyrics.GetLyricIgnoreVoid(time, 1);
+                int next_lyric_index{ now_lyrics.GetLyricIndexIgnoreBlank(lyric_index, 1) };
+                next_lyric = now_lyrics.GetLyricIgnoreBlank(next_lyric_index);
                 if (next_lyric.text.empty())
                     next_lyric.text = CCommon::LoadText(IDS_DEFAULT_LYRIC_TEXT_CORTANA);
-                else if (now_lyrics.GetLyric(time, 1).text.empty() && now_lyrics.GetBlankTimeBeforeLyric(time, 1) > 1000)
+                else if (now_lyrics.GetBlankTimeBeforeLyric(next_lyric_index) > 800)
                     next_lyric.text = L"♪♪♪ " + next_lyric.text;
             }
             SetNextLyric(next_lyric.text.c_str());

--- a/MusicPlayer2/Lyric.cpp
+++ b/MusicPlayer2/Lyric.cpp
@@ -356,6 +356,88 @@ int CLyrics::GetLyricIndex(Time time) const
     return m_lyrics.size() - 1;
 }
 
+CLyrics::Lyric CLyrics::GetLyricIgnoreSpace(Time time, int offset) const
+{
+    int index{ GetLyricIndex(time) };
+
+    // 对齐到非空白歌词
+    if (index >= 0)
+    {
+        for (int i{ index }; i < static_cast<int>(m_lyrics.size()); ++i)
+        {
+            if (!m_lyrics[i].text.empty())
+            {
+                index = i;
+                    break;
+            }
+        }
+    }
+    // 应用偏移量
+    if (offset > 0)
+    {
+        int j{};
+        while (j++ < offset)    // offset>0 时循环 offset 次
+        {
+            if (++index >= static_cast<int>(m_lyrics.size()))
+            {
+                break;
+            }
+            for (int i{ index }; i < static_cast<int>(m_lyrics.size()); ++i)
+            {
+                if (!m_lyrics[i].text.empty())
+                {
+                    index = i;
+                    break;
+                }
+            }
+        }
+    }
+    if (offset < 0)
+    {
+        int j{};
+        while (j-- > offset)    // offset < 0 时循环 -offset 次
+        {
+            if (--index < 0)
+            {
+                break;
+            }
+            for (int i{ index }; i >= 0; --i)
+            {
+                if (!m_lyrics[i].text.empty())
+                {
+                    index = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (index < -1 || index >= static_cast<int>(m_lyrics.size()))
+    {
+        return Lyric{};
+    }
+    else if (index == -1)
+    {
+        Lyric ti{};
+        ti.text = m_ti;
+        return ti;		//时间在第一个时间标签前面，返回ti标签的值
+    }
+    else
+    {
+        return m_lyrics[index];
+    }
+}
+
+int CLyrics::GetLyricIndexIgnoreSpace(Time time) const
+{
+    for (int index{ GetLyricIndex(time) }; index < static_cast<int>(m_lyrics.size()); ++index)
+    {
+        if (!m_lyrics[index].text.empty())
+            return index;
+    }
+    return m_lyrics.size() - 1;
+}
+
 CodeType CLyrics::GetCodeType() const
 {
     return m_code_type;

--- a/MusicPlayer2/Lyric.cpp
+++ b/MusicPlayer2/Lyric.cpp
@@ -356,7 +356,7 @@ int CLyrics::GetLyricIndex(Time time) const
     return m_lyrics.size() - 1;
 }
 
-CLyrics::Lyric CLyrics::GetLyricIgnoreSpace(Time time, int offset) const
+CLyrics::Lyric CLyrics::GetLyricIgnoreVoid(Time time, int offset) const
 {
     int index{ GetLyricIndex(time) };
 
@@ -428,7 +428,7 @@ CLyrics::Lyric CLyrics::GetLyricIgnoreSpace(Time time, int offset) const
     }
 }
 
-int CLyrics::GetLyricIndexIgnoreSpace(Time time) const
+int CLyrics::GetLyricIndexIgnoreVoid(Time time) const
 {
     for (int index{ GetLyricIndex(time) }; index < static_cast<int>(m_lyrics.size()); ++index)
     {

--- a/MusicPlayer2/Lyric.h
+++ b/MusicPlayer2/Lyric.h
@@ -83,6 +83,11 @@ public:
     // 根据时间返回该时间对应的歌词序号（用于判断歌词是否有变化）
     int GetLyricIndex(Time time) const;
 
+    // 根据时间返回一句歌词。第2个参数如果是0，则返回当前时间对应的歌词，如果是-1则返回当前时间的前一句歌词，1则返回后一句歌词，以此类推。
+    Lyric GetLyricIgnoreSpace(Time time, int offset) const;
+    // 根据时间返回该时间对应的歌词序号（用于判断歌词是否有变化）
+    int GetLyricIndexIgnoreSpace(Time time) const;
+
     // 获得歌词文本的编码类型
     CodeType GetCodeType() const;
     // 获取歌词文件的路径+文件名

--- a/MusicPlayer2/Lyric.h
+++ b/MusicPlayer2/Lyric.h
@@ -83,12 +83,15 @@ public:
     // 根据时间返回该时间对应的歌词序号（用于判断歌词是否有变化）
     int GetLyricIndex(Time time) const;
 
-    // 根据时间返回一句歌词。第2个参数如果是0，则返回当前时间对应的歌词，如果是-1则返回当前时间的前一句歌词，1则返回后一句歌词，以此类推。
-    Lyric GetLyricIgnoreVoid(Time time, int offset) const;
-    // 根据时间返回该时间对应的歌词序号（用于判断歌词是否有变化）
-    int GetLyricIndexIgnoreVoid(Time time, int offset) const;
-    // 获取指定歌词之前的空白时长
-    Time CLyrics::GetBlankTimeBeforeLyric(Time time, int offset) const;
+    // 根据索引与偏移量返回该时间对应的歌词索引
+    int GetLyricIndexIgnoreBlank(int index, int offset) const;
+    // 根据索引返回一句歌词(index为-1时返回标题,其他无效索引返回空歌词)
+    Lyric GetLyricIgnoreBlank(int index) const;
+    // 获取指定歌词之前的空白时长(index无效时返回0)
+    Time CLyrics::GetBlankTimeBeforeLyric(int index) const;
+    // 返回该time所对应的空白进度（0~1000）仅当time位于空行中且之后仍有歌词时可用。
+    // (合并空行，要求index为time之后第一句非空歌词，time位于index之前紧邻的空白中)
+    int GetBlankLyricProgress(int index, Time time) const;
 
     // 获得歌词文本的编码类型
     CodeType GetCodeType() const;

--- a/MusicPlayer2/Lyric.h
+++ b/MusicPlayer2/Lyric.h
@@ -4,100 +4,138 @@
 class CLyrics
 {
 public:
-	struct Lyric		//一句歌词的结构体
-	{
-		Time time;		//歌词的时间标签
-		wstring text;	//歌词的文本
-		wstring translate;	//歌词的翻译
+    struct Lyric               // 一句歌词的结构体
+    {
+        Time time;             // 歌词的时间标签
+        wstring text;          // 歌词的文本
+        wstring translate;     // 歌词的翻译
 
-		//重载小于号运算符，用于对歌词按时间标签排序
-		bool operator<(const Lyric& lyric) const
-		{
-			return lyric.time > time;
-		}
+        // 重载小于号运算符，用于对歌词按时间标签排序
+        bool operator<(const Lyric& lyric) const
+        {
+            return lyric.time > time;
+        }
 
-		//根据一个偏移量返回时间
-		Time GetTime(int offset) const
-		{
-			if (offset == 0)
-				return time;
-			else
-				return time + offset;
-		}
-	};
+        // 根据一个偏移量返回时间
+        Time GetTime(int offset) const
+        {
+            if (offset == 0)
+                return time;
+            else
+                return time + offset;
+        }
+    };
 
 private:
-	wstring m_file;		//歌词文件的文件名
-	vector<Lyric> m_lyrics;		//储存每一句歌词（包含时间标签和文本）
-	vector<wstring> m_lyrics_str;	//储存未拆分时间标签的每一句歌词
-	CodeType m_code_type{ CodeType::ANSI };		//歌词文本的编码类型
+    wstring m_file;                            // 歌词文件的文件名
+    vector<Lyric> m_lyrics;                    // 储存每一句歌词（包含时间标签和文本）
+    vector<wstring> m_lyrics_str;              // 储存未拆分时间标签的每一句歌词
+    CodeType m_code_type{ CodeType::ANSI };    // 歌词文本的编码类型
 
-	wstring m_id;		//歌词中的id标签（网易云音乐中的歌曲id，我自己加的，标准的lrc文件没有这个标签）
-	wstring m_ti;		//歌词中的ti标签
-	wstring m_ar;		//歌词中的ar标签
-	wstring m_al;		//歌词中的al标签
-	wstring m_by;		//歌词中的by标签
-	bool m_id_tag{ false };		//歌词中是否含有id标签
-	bool m_ti_tag{ false };		//歌词中是否含有ti标签
-	bool m_ar_tag{ false };		//歌词中是否含有ar标签
-	bool m_al_tag{ false };		//歌词中是否含有al标签
-	bool m_by_tag{ false };		//歌词中是否含有by标签
+    wstring m_id;          // 歌词中的id标签（网易云音乐中的歌曲id，我自己加的，标准的lrc文件没有这个标签）
+    wstring m_ti;          // 歌词中的ti标签
+    wstring m_ar;          // 歌词中的ar标签
+    wstring m_al;          // 歌词中的al标签
+    wstring m_by;          // 歌词中的by标签
+    bool m_id_tag{ false };    // 歌词中是否含有id标签
+    bool m_ti_tag{ false };    // 歌词中是否含有ti标签
+    bool m_ar_tag{ false };    // 歌词中是否含有ar标签
+    bool m_al_tag{ false };    // 歌词中是否含有al标签
+    bool m_by_tag{ false };    // 歌词中是否含有by标签
 
-	int m_offset{};		//歌词偏移量
-	bool m_offset_tag{ false };		//歌词是否包含偏移量标签
-	int m_offset_tag_index{ -1 };			//偏移量标签在第几行（从0开始计）
+    int m_offset{};                            // 歌词偏移量
+    bool m_offset_tag{ false };                // 歌词是否包含偏移量标签
+    int m_offset_tag_index{ -1 };              // 偏移量标签在第几行（从0开始计）
 
-	bool m_modified{ false };		//歌词是否已经修改
-	bool m_chinese_converted{ false };		//是否已经执行了中文繁简转换
-	bool m_translate{ false };		//歌词是否包含翻译
+    bool m_modified{ false };                  // 歌词是否已经修改
+    bool m_chinese_converted{ false };         // 是否已经执行了中文繁简转换
+    bool m_translate{ false };                 // 歌词是否包含翻译
 
-	void DivideLyrics();		//将歌词文件拆分成若干句歌词，并保存在m_lyrics_str中
-	void DisposeLyric();		//获得歌词中的时间标签和歌词文本，并将文本从string类型转换成wstring类型，保存在m_lyrics中
-	//void JudgeCode();		//判断歌词的编码格式
+    // 将歌词文件拆分成若干句歌词，并保存在m_lyrics_str中
+    void DivideLyrics();
+    // 获得歌词中的时间标签和歌词文本，并将文本从string类型转换成wstring类型，保存在m_lyrics中
+    void DisposeLyric();
+    // 判断歌词的编码格式
+    // void JudgeCode();
 
-	//解析一行歌词文本
-	//lyric_text_ori：待解析的歌词文本
-	//lyric_text：解析到的歌词原文
-	//lyric_translate：解析到的歌词翻译
-	static void ParseLyricText(const wstring& lyric_text_ori, wstring& lyric_text, wstring& lyric_translate);
+    // 解析一行歌词文本
+    // lyric_text_ori：待解析的歌词文本
+    // lyric_text：解析到的歌词原文
+    // lyric_translate：解析到的歌词翻译
+    static void ParseLyricText(const wstring& lyric_text_ori, wstring& lyric_text, wstring& lyric_translate);
 
 public:
-	CLyrics(const wstring& file_name);
-	CLyrics() {}
-	void LyricsFromRowString(const wstring& lryic_str);
-	bool IsEmpty() const;		//判断是否有歌词
-	Lyric GetLyric(Time time, int offset) const;		//根据时间返回一句歌词。第2个参数如果是0，则返回当前时间对应的歌词，如果是-1则返回当前时间的前一句歌词，1则返回后一句歌词，以此类推。
-	Lyric GetLyric(int index) const;			//根据索引返回一句歌词
-	int GetLyricProgress(Time time) const;		//根据时间返回该时间所对应的歌词的进度（0~1000）（用于使歌词以卡拉OK样式显示）
-	int GetLyricIndex(Time time) const;			//根据时间返回该时间对应的歌词序号（用于判断歌词是否有变化）
-	CodeType GetCodeType() const;		//获得歌词文本的编码类型
-	wstring GetPathName() const { return m_file; }		//获取歌词文件的路径+文件名
-	wstring GetAllLyricText(bool with_translate = false) const;		//返回所有歌词（仅包含全部歌词文本，不含标识标签和时间标签）。with_translate：是否包含翻译（如果有）
-	wstring GetLyricsString() const;		//返回所有歌词的字符串，原始样式，包含全部标签
-	wstring GetLyricsString2() const;		//返回所有歌词的字符串，以保存的样式，包含全部标签（将歌词偏移保存到每个时间标签中）
-	bool IsModified() const { return m_modified; }
+    CLyrics(const wstring& file_name);
+    CLyrics() {}
+
+    // 从原始歌词字符串加载解析歌词（与构造函数类似）
+    void LyricsFromRowString(const wstring& lryic_str);
+
+    // 判断是否有歌词
+    bool IsEmpty() const;
+
+    // 根据时间返回一句歌词。第2个参数如果是0，则返回当前时间对应的歌词，如果是-1则返回当前时间的前一句歌词，1则返回后一句歌词，以此类推。
+    Lyric GetLyric(Time time, int offset) const;
+    // 根据索引返回一句歌词
+    Lyric GetLyric(int index) const;
+    // 根据时间返回该时间所对应的歌词的进度（0~1000）（用于使歌词以卡拉OK样式显示）
+    int GetLyricProgress(Time time) const;
+    // 根据时间返回该时间对应的歌词序号（用于判断歌词是否有变化）
+    int GetLyricIndex(Time time) const;
+
+    // 获得歌词文本的编码类型
+    CodeType GetCodeType() const;
+    // 获取歌词文件的路径+文件名
+    wstring GetPathName() const { return m_file; }
+    // 返回所有歌词（仅包含全部歌词文本，不含标识标签和时间标签）。with_translate：是否包含翻译（如果有）
+    wstring GetAllLyricText(bool with_translate = false) const;
+    // 返回所有歌词的字符串，原始样式，包含全部标签
+    wstring GetLyricsString() const;
+    // 返回所有歌词的字符串，以保存的样式，包含全部标签（将歌词偏移保存到每个时间标签中）
+    wstring GetLyricsString2() const;
+
+    // 返回歌词修改标志
+    bool IsModified() const { return m_modified; }
+    // 设置歌词更改标志
     void SetModified(bool modified) { m_modified = modified; }
-	bool IsChineseConverted() const { return m_chinese_converted; }
-	bool IsTranslated() const { return m_translate; }
-	int GetLyricCount() const{ return m_lyrics.size(); }
+    // 返回繁简转换标志
+    bool IsChineseConverted() const { return m_chinese_converted; }
+    // 返回歌词是否含有翻译
+    bool IsTranslated() const { return m_translate; }
 
-	void SaveLyric();		//保存歌词（将歌词偏移保存在offset标签中）
-	void SaveLyric2();		//保存歌词（将歌词偏移保存到每个时间标签中）
+    // 返回歌词总数
+    int GetLyricCount() const{ return m_lyrics.size(); }
 
-	void CombineSameTimeLyric();	//如果歌词中有相同时间标签的歌词，则将其文本合并，保留一个时间标签（用于处理下载到的带翻译的歌词）（使用时必须确保歌词已经按时间标签排序）
-	void DeleteRedundantLyric();	//删除歌词中时间标签超过100分钟的歌词（使用时必须确保歌词已经按时间标签排序）
-    void SwapTextAndTranslation();      //交换歌词文本和翻译
-    void TimeTagForward();          //时间标签提前一句
-    void TimeTagDelay();            //时间标签延后一句
-	// 从歌词原文的括号中提取翻译，丢弃原有翻译
-	void ExtractTranslationFromBrackets();
+    // 保存歌词（将歌词偏移保存在offset标签中）
+    void SaveLyric();
+    // 保存歌词（将歌词偏移保存到每个时间标签中）
+    void SaveLyric2();
 
-	void AdjustLyric(int offset);	//调整歌词的偏移量
+    // 如果歌词中有相同时间标签的歌词，则将其文本合并，保留一个时间标签（用于处理下载到的带翻译的歌词）（使用时必须确保歌词已经按时间标签排序）
+    void CombineSameTimeLyric();
+    // 删除歌词中时间标签超过100分钟的歌词（使用时必须确保歌词已经按时间标签排序）
+    void DeleteRedundantLyric();
 
+    // 交换歌词文本和翻译
+    void SwapTextAndTranslation();
+    // 时间标签提前一句
+    void TimeTagForward();
+    // 时间标签延后一句
+    void TimeTagDelay();
+    // 从歌词原文的括号中提取翻译，丢弃原有翻译
+    void ExtractTranslationFromBrackets();
+    // 调整歌词的偏移量
+    void AdjustLyric(int offset);
+
+    // 获取标题
     wstring GetTitle() const { return m_ti; }
+    // 获取艺术家
     wstring GetAritst() const { return m_ar; }
+    // 获取专辑
     wstring GetAlbum() const { return m_al; }
-	wstring GetSongId() const { return m_id; }		//获取保存在歌词中的网易云音乐的歌曲ID
+    // 获取保存在歌词中的网易云音乐的歌曲ID
+    wstring GetSongId() const { return m_id; }
 
-	void ChineseConvertion(bool simplified);		//中文繁简转换
+    // 中文繁简转换
+    void ChineseConvertion(bool simplified);
 };

--- a/MusicPlayer2/Lyric.h
+++ b/MusicPlayer2/Lyric.h
@@ -84,9 +84,9 @@ public:
     int GetLyricIndex(Time time) const;
 
     // 根据时间返回一句歌词。第2个参数如果是0，则返回当前时间对应的歌词，如果是-1则返回当前时间的前一句歌词，1则返回后一句歌词，以此类推。
-    Lyric GetLyricIgnoreSpace(Time time, int offset) const;
+    Lyric GetLyricIgnoreVoid(Time time, int offset) const;
     // 根据时间返回该时间对应的歌词序号（用于判断歌词是否有变化）
-    int GetLyricIndexIgnoreSpace(Time time) const;
+    int GetLyricIndexIgnoreVoid(Time time) const;
 
     // 获得歌词文本的编码类型
     CodeType GetCodeType() const;

--- a/MusicPlayer2/Lyric.h
+++ b/MusicPlayer2/Lyric.h
@@ -86,7 +86,9 @@ public:
     // 根据时间返回一句歌词。第2个参数如果是0，则返回当前时间对应的歌词，如果是-1则返回当前时间的前一句歌词，1则返回后一句歌词，以此类推。
     Lyric GetLyricIgnoreVoid(Time time, int offset) const;
     // 根据时间返回该时间对应的歌词序号（用于判断歌词是否有变化）
-    int GetLyricIndexIgnoreVoid(Time time) const;
+    int GetLyricIndexIgnoreVoid(Time time, int offset) const;
+    // 获取指定歌词之前的空白时长
+    Time CLyrics::GetBlankTimeBeforeLyric(Time time, int offset) const;
 
     // 获得歌词文本的编码类型
     CodeType GetCodeType() const;

--- a/MusicPlayer2/LyricsWindow.cpp
+++ b/MusicPlayer2/LyricsWindow.cpp
@@ -143,9 +143,19 @@ BOOL CLyricsWindow::RegisterWndClass(LPCTSTR lpszClassName)
 }
 
 
+//更新歌词(进度符号,歌词文本,高亮进度百分比,是否为进度符号高亮)
+void CLyricsWindow::UpdateLyrics(LPCTSTR lpszBeforeLyrics, LPCTSTR lpszLyrics, int nHighlight, bool bBeforeLyrics)
+{
+    m_lpszBeforeLyrics = lpszBeforeLyrics;
+    m_bBeforeLyrics = bBeforeLyrics;
+    m_lpszLyrics = lpszLyrics;
+    UpdateLyrics(nHighlight);
+}
 //更新歌词(歌词文本,高亮进度百分比)
 void CLyricsWindow::UpdateLyrics(LPCTSTR lpszLyrics,int nHighlight)
 {
+    m_lpszBeforeLyrics.Empty();
+    m_bBeforeLyrics = false;
     m_lpszLyrics = lpszLyrics;
     UpdateLyrics(nHighlight);
 }
@@ -296,7 +306,23 @@ void CLyricsWindow::DrawLyrics(Gdiplus::Graphics* pGraphics)
 	//先取出文字宽度和高度
 	Gdiplus::RectF layoutRect(0,0,0,0);
 	Gdiplus::RectF boundingBox;
-	pGraphics->MeasureString (m_lpszLyrics, -1, m_pFont,layoutRect, m_pTextFormat,&boundingBox, 0, 0);
+    if (!m_lpszBeforeLyrics.IsEmpty())
+    {
+        pGraphics->MeasureString(m_lpszBeforeLyrics, -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+        auto bef_width{ boundingBox.Width };
+        pGraphics->MeasureString(L" ", -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+        auto sp_width{ boundingBox.Width };
+        m_lpszLyrics = m_lpszBeforeLyrics + L" " + m_lpszLyrics;
+        pGraphics->MeasureString(m_lpszLyrics, -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+        if(m_bBeforeLyrics)
+            m_nHighlight = m_nHighlight * bef_width / boundingBox.Width;
+        else
+            m_nHighlight = ((bef_width + sp_width) * 1000 + m_nHighlight * (boundingBox.Width - bef_width - sp_width)) / boundingBox.Width;
+    }
+	else
+	{
+		pGraphics->MeasureString (m_lpszLyrics, -1, m_pFont,layoutRect, m_pTextFormat,&boundingBox, 0, 0);
+	}
 	//计算歌词画出的位置
 	Gdiplus::RectF dstRect;		//文字的矩形
 	Gdiplus::RectF transRect;	//翻译文本的矩形
@@ -355,7 +381,23 @@ void CLyricsWindow::DrawLyricsDoubleLine(Gdiplus::Graphics* pGraphics)
     //先取出文字宽度和高度
     Gdiplus::RectF layoutRect(0, 0, 0, 0);
     Gdiplus::RectF boundingBox;
-    pGraphics->MeasureString(m_lpszLyrics, -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+    if (!m_lpszBeforeLyrics.IsEmpty())
+    {
+        pGraphics->MeasureString(m_lpszBeforeLyrics, -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+        auto bef_width{ boundingBox.Width };
+        pGraphics->MeasureString(L" ", -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+        auto sp_width{ boundingBox.Width };
+        m_lpszLyrics = m_lpszBeforeLyrics + L" " + m_lpszLyrics;
+        pGraphics->MeasureString(m_lpszLyrics, -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+        if (m_bBeforeLyrics)
+            m_nHighlight = m_nHighlight * bef_width / boundingBox.Width;
+        else
+            m_nHighlight = ((bef_width + sp_width) * 1000 + m_nHighlight * (boundingBox.Width - bef_width - sp_width)) / boundingBox.Width;
+    }
+    else
+    {
+        pGraphics->MeasureString(m_lpszLyrics, -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+    }
     Gdiplus::RectF nextBoundingBox;
     pGraphics->MeasureString(m_strNextLyric, -1, m_pFont, layoutRect, m_pTextFormat, &nextBoundingBox, 0, 0);
     //计算歌词画出的位置

--- a/MusicPlayer2/LyricsWindow.h
+++ b/MusicPlayer2/LyricsWindow.h
@@ -52,6 +52,8 @@ public:
 	BOOL Create(LPCTSTR lpszClassName);
 	BOOL Create(LPCTSTR lpszClassName,int nWidth,int nHeight);
 public:
+    //更新歌词(进度符号,歌词文本,高亮进度百分比,是否为进度符号高亮)
+    void UpdateLyrics(LPCTSTR lpszBeforeLyrics, LPCTSTR lpszLyrics, int nHighlight, bool bBeforeLyrics);
 	//更新歌词(歌词文本,高亮进度百分比)
 	void UpdateLyrics(LPCTSTR lpszLyrics,int nHighlight);
 	//更新高亮进度(高亮进度百分比)
@@ -111,8 +113,10 @@ private:
 	HDC m_hCacheDC;//缓存DC
 	int m_nWidth;
 	int m_nHeight;
+    CString m_lpszBeforeLyrics;//进度符号,Unicode格式
 	CString m_lpszLyrics;//Unicode格式的歌词
 	int m_nHighlight;//高亮歌词的百分比 0--1000
+    bool m_bBeforeLyrics;//高亮进度描述歌词前符号
 	Gdiplus::Color m_TextColor1;//普通歌词颜色,ARGB颜色
 	Gdiplus::Color m_TextColor2;//普通歌词颜色,ARGB颜色
 	LyricsGradientMode m_TextGradientMode;//普通歌词渐变模式

--- a/MusicPlayer2/MusicPlayerDlg.cpp
+++ b/MusicPlayer2/MusicPlayerDlg.cpp
@@ -366,6 +366,7 @@ void CMusicPlayerDlg::SaveConfig()
     ini.WriteInt(L"desktop_lyric", L"opacity", theApp.m_lyric_setting_data.desktop_lyric_data.opacity);
     ini.WriteBool(L"desktop_lyric", L"show_unlock_when_locked", theApp.m_lyric_setting_data.desktop_lyric_data.show_unlock_when_locked);
     ini.WriteInt(L"desktop_lyric", L"lyric_align", static_cast<int>(theApp.m_lyric_setting_data.desktop_lyric_data.lyric_align));
+    ini.WriteBool(L"desktop_lyric", L"display_void_line", theApp.m_lyric_setting_data.desktop_lyric_data.display_void_line);
     ini.WriteInt(L"desktop_lyric", L"position_x", m_desktop_lyric_pos.x);
     ini.WriteInt(L"desktop_lyric", L"position_y", m_desktop_lyric_pos.y);
     ini.WriteInt(L"desktop_lyric", L"width", m_desktop_lyric_size.cx);
@@ -523,6 +524,7 @@ void CMusicPlayerDlg::LoadConfig()
     theApp.m_lyric_setting_data.desktop_lyric_data.opacity = ini.GetInt(L"desktop_lyric", L"opacity", 100);
     theApp.m_lyric_setting_data.desktop_lyric_data.show_unlock_when_locked = ini.GetBool(L"desktop_lyric", L"show_unlock_when_locked", true);
     theApp.m_lyric_setting_data.desktop_lyric_data.lyric_align = static_cast<Alignment>(ini.GetInt(L"desktop_lyric", L"lyric_align", static_cast<int>(Alignment::CENTER)));
+    theApp.m_lyric_setting_data.desktop_lyric_data.display_void_line = ini.GetBool(L"desktop_lyric", L"display_void_line", true);
     m_desktop_lyric_pos.x = ini.GetInt(L"desktop_lyric", L"position_x", -1);
     m_desktop_lyric_pos.y = ini.GetInt(L"desktop_lyric", L"position_y", -1);
     m_desktop_lyric_size.cx = ini.GetInt(L"desktop_lyric", L"width", 0);


### PR DESCRIPTION
想不到怎样在设置里描述这个功能，目前没加（也没写完）。

目前在DesktopLyric.h的112行
progress = 0;  // 通过忽略空白得到的歌词还没到显示的时间，清0进度
是临时处理，此处我希望改成调用CLyrics类的一个方法（还没写）取得当前Time对应空白时长是否大于一个阈值
（或者直接返回空白长度）。
如果小于阈值progress = 0; 不变，大于阈值时标记一个bool变量指示在下一句歌词前显示空白进度。
即在下一句歌词前加几个符号在上面显示空白进度（就像过去的卡拉OK）
重载UpdateLyrics将显示空白进度传达到CLyricsWindow之后需要CLyricsWindow的绘制支持。
这里完全不会写。

获取空白进度的方法想沿用GetLyricProgress不做更改，这样就要求载入歌词时按时间排序后合并连续空白项。
不知道会不会有歌词刻意使用有意义的连续空行，如果空行不能随意合并则还需要一个获取空白进度用的GetLyricProgress版本。
@zhongyang219 

---

测试发现的一个歌词，Debug歌词编辑窗口向下滚动到特定位置会触发LexAccessor.h第166行的断言。
Release感觉没问题。
[WITCH NUMBER 4 - PRIZM♪RIZM.zip](https://github.com/zhongyang219/MusicPlayer2/files/6808892/WITCH.NUMBER.4.-.PRIZM.RIZM.zip)
