### PR TITLE
界面修正+桌面歌词多屏幕

### DIFF
--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -1689,3 +1689,35 @@ CString CCommon::GetDesktopBackgroundPath()
     }
     return path;
 }
+
+POINT CCommon::CheckWindowPos(CRect& check_rect, vector<CRect>& screen_rects)
+{
+    POINT mov{};                                                        // 所需偏移量
+    // 确保窗口在一个监视器内并且可见，判断移动距离并向所需移动距离较小的方向移动
+    LONG mov_xy = 0;                                                    // 记录移动距离
+    for (auto& a : screen_rects)
+    {
+        LONG x = 0, y = 0;
+        if (check_rect.left < a.left || check_rect.Width() > a.Width()) // 需要向右移动
+            x = a.left - check_rect.left;
+        else if (check_rect.right > a.right)                            // 需要向左移动
+            x = a.right - check_rect.right;
+        if (check_rect.top < a.top || check_rect.Height() > a.Height()) // 需要向下移动
+            y = a.top - check_rect.top;
+        else if (check_rect.bottom > a.bottom)                          // 需要向上移动
+            y = a.bottom - check_rect.bottom;
+        if (x == 0 && y == 0)                                           // 窗口已在一个监视器内
+        {
+            mov.x = 0;
+            mov.y = 0;
+            break;
+        }
+        else if (abs(x) + abs(y) < mov_xy || mov_xy == 0)
+        {
+            mov.x = x;
+            mov.y = y;
+            mov_xy = abs(x) + abs(y);
+        }
+    }
+    return mov;
+}

--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -1698,14 +1698,14 @@ POINT CCommon::CalculateWindowMoveOffset(CRect& check_rect, vector<CRect>& scree
     for (auto& a : screen_rects)
     {
         LONG x = 0, y = 0;
-        if (check_rect.right > a.right)                                 // 需要向左移动
-            x = a.right - check_rect.right;
-        if (check_rect.left < a.left)                                   // 需要向右移动(当check_rect水平方向大于a时左对齐)
+        if (check_rect.left < a.left || check_rect.Width() > a.Width()) // 需要向右移动
             x = a.left - check_rect.left;
-        if (check_rect.bottom > a.bottom)                               // 需要向上移动
-            y = a.bottom - check_rect.bottom;
-        if (check_rect.top < a.top)                                     // 需要向下移动(当check_rect垂直方向大于a时上对齐)
+        else if (check_rect.right > a.right)                            // 需要向左移动
+            x = a.right - check_rect.right;
+        if (check_rect.top < a.top || check_rect.Height() > a.Height()) // 需要向下移动
             y = a.top - check_rect.top;
+        else if (check_rect.bottom > a.bottom)                          // 需要向上移动
+            y = a.bottom - check_rect.bottom;
         if (x == 0 && y == 0)                                           // 窗口已在一个监视器内
         {
             mov.x = 0;

--- a/MusicPlayer2/Common.cpp
+++ b/MusicPlayer2/Common.cpp
@@ -1690,7 +1690,7 @@ CString CCommon::GetDesktopBackgroundPath()
     return path;
 }
 
-POINT CCommon::CheckWindowPos(CRect& check_rect, vector<CRect>& screen_rects)
+POINT CCommon::CalculateWindowMoveOffset(CRect& check_rect, vector<CRect>& screen_rects)
 {
     POINT mov{};                                                        // 所需偏移量
     // 确保窗口在一个监视器内并且可见，判断移动距离并向所需移动距离较小的方向移动
@@ -1698,14 +1698,14 @@ POINT CCommon::CheckWindowPos(CRect& check_rect, vector<CRect>& screen_rects)
     for (auto& a : screen_rects)
     {
         LONG x = 0, y = 0;
-        if (check_rect.left < a.left || check_rect.Width() > a.Width()) // 需要向右移动
-            x = a.left - check_rect.left;
-        else if (check_rect.right > a.right)                            // 需要向左移动
+        if (check_rect.right > a.right)                                 // 需要向左移动
             x = a.right - check_rect.right;
-        if (check_rect.top < a.top || check_rect.Height() > a.Height()) // 需要向下移动
-            y = a.top - check_rect.top;
-        else if (check_rect.bottom > a.bottom)                          // 需要向上移动
+        if (check_rect.left < a.left)                                   // 需要向右移动(当check_rect水平方向大于a时左对齐)
+            x = a.left - check_rect.left;
+        if (check_rect.bottom > a.bottom)                               // 需要向上移动
             y = a.bottom - check_rect.bottom;
+        if (check_rect.top < a.top)                                     // 需要向下移动(当check_rect垂直方向大于a时上对齐)
+            y = a.top - check_rect.top;
         if (x == 0 && y == 0)                                           // 窗口已在一个监视器内
         {
             mov.x = 0;

--- a/MusicPlayer2/Common.h
+++ b/MusicPlayer2/Common.h
@@ -411,7 +411,7 @@ public:
     static CString GetDesktopBackgroundPath();  //获取桌面壁纸的路径
 
     //返回使窗口显示在一个监视器内所需移动距离最小的偏移量 (当check_rect在某方向上大于screen_rects时向左或向上对齐)
-    static POINT CheckWindowPos(CRect& check_rect, vector<CRect>& screen_rects);
+    static POINT CalculateWindowMoveOffset(CRect& check_rect, vector<CRect>& screen_rects);
 
 };
 

--- a/MusicPlayer2/Common.h
+++ b/MusicPlayer2/Common.h
@@ -410,6 +410,9 @@ public:
 
     static CString GetDesktopBackgroundPath();  //获取桌面壁纸的路径
 
+    //返回使窗口显示在一个监视器内所需移动距离最小的偏移量 (当check_rect在某方向上大于screen_rects时向左或向上对齐)
+    static POINT CheckWindowPos(CRect& check_rect, vector<CRect>& screen_rects);
+
 };
 
 template<class T>

--- a/MusicPlayer2/LyricsWindow.cpp
+++ b/MusicPlayer2/LyricsWindow.cpp
@@ -358,8 +358,10 @@ void CLyricsWindow::DrawLyricsDoubleLine(Gdiplus::Graphics* pGraphics)
     Gdiplus::RectF layoutRect(0, 0, 0, 0);
     Gdiplus::RectF boundingBox;
     pGraphics->MeasureString(m_lpszLyrics, -1, m_pFont, layoutRect, m_pTextFormat, &boundingBox, 0, 0);
+    boundingBox.Width += 1;     //测量到的文本宽度加1，以防止出现使用某些字体时，最后一个字符无法显示的问题
     Gdiplus::RectF nextBoundingBox;
     pGraphics->MeasureString(m_strNextLyric, -1, m_pFont, layoutRect, m_pTextFormat, &nextBoundingBox, 0, 0);
+    nextBoundingBox.Width += 1; //测量到的文本宽度加1，以防止出现使用某些字体时，最后一个字符无法显示的问题
     //计算歌词画出的位置
     Gdiplus::RectF dstRect;		//文字的矩形
     Gdiplus::RectF nextRect;	//下一句文本的矩形

--- a/MusicPlayer2/MiniModeDlg.cpp
+++ b/MusicPlayer2/MiniModeDlg.cpp
@@ -59,46 +59,11 @@ void CMiniModeDlg::LoadConfig()
     m_always_on_top = ini.GetBool(_T("mini_mode"), _T("always_on_top"), true);
 }
 
-POINT CMiniModeDlg::CheckWindowPos(CRect rect)
-{
-    POINT mov{};    // 所需偏移量
-    if (m_screen_rects.size() != 0)
-    {
-        // 确保窗口完整在一个监视器内并且可见，判断移动距离并向所需移动距离较小的方向移动
-        LONG mov_xy = 0;          // 记录移动距离
-        for (auto& a : m_screen_rects)
-        {
-            LONG x = 0, y = 0;
-            if (rect.left < a.left)                 // 需要向右移动
-                x = a.left - rect.left;
-            else if (rect.right > a.right)          // 需要向左移动
-                x = a.right - rect.right;
-            if (rect.top < a.top)                   // 需要向下移动
-                y = a.top - rect.top;
-            else if (rect.bottom > a.bottom)        // 需要向上移动
-                y = a.bottom - rect.bottom;
-            if (x == 0 && y == 0)           // mini窗口已在一个监视器内
-            {
-                mov.x = 0;
-                mov.y = 0;
-                break;
-            }
-            else if (abs(x) + abs(y) < mov_xy || mov_xy == 0)
-            {
-                mov.x = x;
-                mov.y = y;
-                mov_xy = abs(x) + abs(y);
-            }
-        }
-    }
-    return mov;
-}
-
 void CMiniModeDlg::MoveWindowPos()
 {
     CRect rect;
     GetWindowRect(rect);
-    MoveWindow(rect + CheckWindowPos(rect));
+    MoveWindow(rect + CCommon::CheckWindowPos(rect, m_screen_rects));
 }
 
 void CMiniModeDlg::UpdateSongTipInfo()
@@ -594,7 +559,7 @@ void CMiniModeDlg::OnShowPlayList()
     else
     {
         rect.bottom = rect.top + m_ui_data.window_height2;
-        POINT tmp{ CheckWindowPos(rect) };    // 向下展开播放列表所需偏移量
+        POINT tmp{ CCommon::CheckWindowPos(rect, m_screen_rects) };    // 向下展开播放列表所需偏移量
         ASSERT(tmp.x == 0); // 此函数不处理横向偏移，需要由OnExitSizeMove及MoveWindowPos保证横向在屏幕内
         // 向下展开播放列表并记录窗口还原偏移量，自行拖动窗口时偏移量会清零
         m_playlist_y_offset = -tmp.y;

--- a/MusicPlayer2/MiniModeDlg.cpp
+++ b/MusicPlayer2/MiniModeDlg.cpp
@@ -32,16 +32,6 @@ void CMiniModeDlg::DoDataExchange(CDataExchange* pDX)
     DDX_Control(pDX, IDC_LIST2, m_playlist_ctrl);
 }
 
-void CMiniModeDlg::GetScreenInfo()
-{
-    m_screen_rects.clear();
-    Monitors monitors;
-    for (auto& a : monitors.monitorinfos)
-    {
-        m_screen_rects.push_back(a.rcWork);
-    }
-}
-
 void CMiniModeDlg::SaveConfig() const
 {
     CIniHelper ini(theApp.m_config_path);
@@ -57,13 +47,6 @@ void CMiniModeDlg::LoadConfig()
     m_position_x = ini.GetInt(L"mini_mode", L"position_x", -1);
     m_position_y = ini.GetInt(_T("mini_mode"), _T("position_y"), -1);
     m_always_on_top = ini.GetBool(_T("mini_mode"), _T("always_on_top"), true);
-}
-
-void CMiniModeDlg::MoveWindowPos()
-{
-    CRect rect;
-    GetWindowRect(rect);
-    MoveWindow(rect + CCommon::CheckWindowPos(rect, m_screen_rects));
 }
 
 void CMiniModeDlg::UpdateSongTipInfo()
@@ -125,7 +108,6 @@ BEGIN_MESSAGE_MAP(CMiniModeDlg, CDialogEx)
     ON_MESSAGE(WM_LIST_ITEM_DRAGGED, &CMiniModeDlg::OnListItemDragged)
     ON_COMMAND(ID_MINI_MODE_ALWAYS_ON_TOP, &CMiniModeDlg::OnMiniModeAlwaysOnTop)
     //ON_MESSAGE(WM_TIMER_INTERVAL_CHANGED, &CMiniModeDlg::OnTimerIntervalChanged)
-    ON_MESSAGE(WM_DISPLAYCHANGE, &CMiniModeDlg::OnDisplaychange)
     ON_WM_EXITSIZEMOVE()
 END_MESSAGE_MAP()
 
@@ -161,15 +143,19 @@ void CMiniModeDlg::SetPlayListColor()
 //	m_ui_data.pDisplayFormat = pDisplayFormat;
 //}
 //
+void CMiniModeDlg::MoveWindowPos()
+{
+    CRect rect;
+    GetWindowRect(rect);
+    MoveWindow(rect + CCommon::CalculateWindowMoveOffset(rect, theApp.m_screen_rects));
+}
+
 BOOL CMiniModeDlg::OnInitDialog()
 {
     CDialogEx::OnInitDialog();
 
     // TODO:  在此添加额外的初始化
     m_playlist_ctrl.SetFont(theApp.m_pMainWnd->GetFont());
-
-    // 获取屏幕信息
-    GetScreenInfo();
 
     LoadConfig();
 
@@ -559,7 +545,7 @@ void CMiniModeDlg::OnShowPlayList()
     else
     {
         rect.bottom = rect.top + m_ui_data.window_height2;
-        POINT tmp{ CCommon::CheckWindowPos(rect, m_screen_rects) };    // 向下展开播放列表所需偏移量
+        POINT tmp{ CCommon::CalculateWindowMoveOffset(rect, theApp.m_screen_rects) };    // 向下展开播放列表所需偏移量
         ASSERT(tmp.x == 0); // 此函数不处理横向偏移，需要由OnExitSizeMove及MoveWindowPos保证横向在屏幕内
         // 向下展开播放列表并记录窗口还原偏移量，自行拖动窗口时偏移量会清零
         m_playlist_y_offset = -tmp.y;
@@ -636,14 +622,6 @@ void CMiniModeDlg::OnMiniModeAlwaysOnTop()
 //    SetTimer(TIMER_ID_MINI2, theApp.m_app_setting_data.ui_refresh_interval, NULL);		//设置用于界面刷新的定时器
 //    return 0;
 //}
-
-
-afx_msg LRESULT CMiniModeDlg::OnDisplaychange(WPARAM wParam, LPARAM lParam)
-{
-    GetScreenInfo();
-    MoveWindowPos();
-    return 0;
-}
 
 
 void CMiniModeDlg::OnExitSizeMove()

--- a/MusicPlayer2/MiniModeDlg.h
+++ b/MusicPlayer2/MiniModeDlg.h
@@ -98,7 +98,6 @@ protected:
     void SaveConfig() const;
     void LoadConfig();
 
-    POINT CheckWindowPos(CRect rect);
     void MoveWindowPos();
     void UpdateSongTipInfo();
     void SetTitle();

--- a/MusicPlayer2/MiniModeDlg.h
+++ b/MusicPlayer2/MiniModeDlg.h
@@ -29,6 +29,8 @@ public:
     //void SetDefaultBackGround(CImage* pImage);
     //void SetDisplayFormat(DisplayFormat* pDisplayFormat);
 
+    void MoveWindowPos();
+
     void SetVolume(bool up);	//
     void SetTransparency();
 
@@ -43,30 +45,6 @@ protected:
 
     int m_position_x;
     int m_position_y;
-
-    vector<CRect> m_screen_rects;       // 屏幕的范围
-
-    // https://www.jianshu.com/p/9d4b68cdbd99
-    struct Monitors
-    {
-        std::vector<MONITORINFO> monitorinfos;
-
-        static BOOL CALLBACK MonitorEnum(HMONITOR hMon, HDC hdc, LPRECT lprcMonitor, LPARAM pData)
-        {
-            MONITORINFO iMonitor;
-            iMonitor.cbSize = sizeof(MONITORINFO);
-            GetMonitorInfo(hMon, &iMonitor);
-
-            Monitors* pThis = reinterpret_cast<Monitors*>(pData);
-            pThis->monitorinfos.push_back(iMonitor);
-            return TRUE;
-        }
-
-        Monitors()
-        {
-            EnumDisplayMonitors(0, 0, MonitorEnum, (LPARAM)this);
-        }
-    };
 
     bool m_show_playlist{ false };		//是否显示播放列表
     LONG m_playlist_y_offset{};         //播放列表收起时窗口需要进行的y坐标偏移量
@@ -93,12 +71,9 @@ protected:
 protected:
     virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV 支持
 
-    void GetScreenInfo();
-
     void SaveConfig() const;
     void LoadConfig();
 
-    void MoveWindowPos();
     void UpdateSongTipInfo();
     void SetTitle();
     void SetAlwaysOnTop();
@@ -138,7 +113,6 @@ public:
     afx_msg void OnMiniModeAlwaysOnTop();
 protected:
     //afx_msg LRESULT OnTimerIntervalChanged(WPARAM wParam, LPARAM lParam);
-    afx_msg LRESULT OnDisplaychange(WPARAM wParam, LPARAM lParam);
 public:
     afx_msg void OnExitSizeMove();
 };

--- a/MusicPlayer2/MusicPlayer2.h
+++ b/MusicPlayer2/MusicPlayer2.h
@@ -42,6 +42,8 @@ public:
 
     vector<DeviceInfo> m_output_devices;	//播放设备的信息
 
+    vector<CRect> m_screen_rects;                   // 屏幕的范围
+
     //CMediaClassifier m_artist_classifer{ CMediaClassifier::CT_ARTIST, true };     //将所有歌曲信息按艺术家分类
     //CMediaClassifier m_album_classifer{ CMediaClassifier::CT_ALBUM, true };       //将所有歌曲信息按唱片集分类
     //CMediaClassifier m_genre_classifer{ CMediaClassifier::CT_GENRE, true };       //将所有歌曲信息按流派分类

--- a/MusicPlayer2/MusicPlayerDlg.cpp
+++ b/MusicPlayer2/MusicPlayerDlg.cpp
@@ -4476,6 +4476,12 @@ void CMusicPlayerDlg::OnFullScreen()
         ShowSizebox(!theApp.m_ui_data.full_screen);
 
     SetFullScreen(theApp.m_ui_data.full_screen);
+
+    // 清空按钮区域，防止全屏时自绘标题栏按钮区域仍能响应
+    auto pCurUi = GetCurrentUi();
+    if (pCurUi != nullptr)
+        pCurUi->ClearBtnRect();
+
     DrawInfo(true);
     m_pUI->UpdateFullScreenTip();
 }

--- a/MusicPlayer2/MusicPlayerDlg.cpp
+++ b/MusicPlayer2/MusicPlayerDlg.cpp
@@ -3043,13 +3043,18 @@ void CMusicPlayerDlg::OnHotKey(UINT nHotKeyId, UINT nKey1, UINT nKey2)
         break;
     case HK_EXIT:
         OnMenuExit();
+        break;
     case HK_SHOW_HIDE_PLAYER:
     {
-        if (IsWindowVisible())
+        if (m_miniModeDlg.m_hWnd != NULL)             // 如果是mini模式则返回标准窗口
+        {
+            ::SendMessageW(m_miniModeDlg.m_hWnd, WM_COMMAND, IDOK, 0);
+        }
+        else if (GetActiveWindow() == this)           // 如果窗口拥有焦点则隐藏
         {
             ShowWindow(SW_HIDE);
         }
-        else
+        else                                          // 进行窗口恢复并取得焦点
         {
             if (IsIconic())
                 ShowWindow(SW_RESTORE);

--- a/MusicPlayer2/MusicPlayerDlg.h
+++ b/MusicPlayer2/MusicPlayerDlg.h
@@ -153,6 +153,30 @@ protected:
 
     CDevicesManager* devicesManager;
 
+    vector<CRect> m_screen_rects;       // 屏幕的范围
+
+    // 来自https://www.jianshu.com/p/9d4b68cdbd99
+    struct Monitors
+    {
+        std::vector<MONITORINFO> monitorinfos;
+
+        static BOOL CALLBACK MonitorEnum(HMONITOR hMon, HDC hdc, LPRECT lprcMonitor, LPARAM pData)
+        {
+            MONITORINFO iMonitor;
+            iMonitor.cbSize = sizeof(MONITORINFO);
+            GetMonitorInfo(hMon, &iMonitor);
+
+            Monitors* pThis = reinterpret_cast<Monitors*>(pData);
+            pThis->monitorinfos.push_back(iMonitor);
+            return TRUE;
+        }
+
+        Monitors()
+        {
+            EnumDisplayMonitors(0, 0, MonitorEnum, (LPARAM)this);
+        }
+    };
+
 private:
     void SaveConfig();		//保存设置到ini文件
     void LoadConfig();		//从ini文件读取设置
@@ -211,6 +235,9 @@ protected:
     void SelectUi(int ui_selected);
     int GetUiSelected() const;
     CPlayerUIBase* GetCurrentUi();
+
+    void GetScreenInfo();
+    void MoveDesktopLyricWindowPos();
 
     // 生成的消息映射函数
     virtual BOOL OnInitDialog();

--- a/MusicPlayer2/MusicPlayerDlg.h
+++ b/MusicPlayer2/MusicPlayerDlg.h
@@ -153,8 +153,6 @@ protected:
 
     CDevicesManager* devicesManager;
 
-    vector<CRect> m_screen_rects;       // 屏幕的范围
-
     // 来自https://www.jianshu.com/p/9d4b68cdbd99
     struct Monitors
     {


### PR DESCRIPTION
桌面歌词显示不再移动到显示一半，改为全部显示。
由主窗口维护m_screen_rects并在OnDisplaychange时调整子窗口位置。
m_screen_rects声明在CMusicPlayerApp作为全局变量。

在测量宽度加1处与 #223 有冲突，223还没写完，这个分枝需要在223之前合并。