### PR TITLE
通过下拉菜单切换到播放列表时选项“切换播放列表时继续播放”修复

### DIFF
--- a/MusicPlayer2/FilePathHelper.h
+++ b/MusicPlayer2/FilePathHelper.h
@@ -2,22 +2,31 @@
 class CFilePathHelper
 {
 public:
-	CFilePathHelper(const wstring& file_path);
-	CFilePathHelper(){}
-	~CFilePathHelper();
+    CFilePathHelper(const wstring& file_path);
+    CFilePathHelper(){}
+    ~CFilePathHelper();
 
-	void SetFilePath(const wstring& file_path) { m_file_path = file_path; }
+    void SetFilePath(const wstring& file_path) { m_file_path = file_path; }
 
-	wstring GetFileExtension(bool upper = false, bool width_dot = false) const;		//获取文件的扩展名(upper:是否大写; width_dot:是否包含“.”)
-	wstring GetFileName() const;							//获取文件名
-	wstring GetFileNameWithoutExtension() const;			//获取文件名（不含扩展名）
-	wstring GetFolderName() const;							//获取文件夹名
-	wstring GetDir() const;									//获取目录
-	wstring GetParentDir() const;							//获取上级目录
-	wstring GetFilePath() const { return m_file_path; }		//获取完整路径
-	const wstring& ReplaceFileExtension(const wchar_t* new_extension);		//替换文件的扩展名，返回文件完整路径
-    wstring GetFilePathWithoutExtension() const;            //获取文件路径（不含扩展名）
+    // 获取文件的扩展名(upper:是否大写; width_dot:是否包含“.”)
+    wstring GetFileExtension(bool upper = false, bool width_dot = false) const;
+    // 获取文件名
+    wstring GetFileName() const;
+    // 获取文件名（不含扩展名）
+    wstring GetFileNameWithoutExtension() const;
+    // 获取文件夹名
+    wstring GetFolderName() const;
+    // 获取目录
+    wstring GetDir() const;
+    // 获取上级目录
+    wstring GetParentDir() const;
+    // 获取完整路径
+    wstring GetFilePath() const { return m_file_path; }
+    // 替换文件的扩展名，返回文件完整路径
+    const wstring& ReplaceFileExtension(const wchar_t* new_extension);
+    // 获取文件路径（不含扩展名）
+    wstring GetFilePathWithoutExtension() const;
 protected:
-	wstring m_file_path;
+    wstring m_file_path;
 };
 

--- a/MusicPlayer2/MusicPlayerDlg.cpp
+++ b/MusicPlayer2/MusicPlayerDlg.cpp
@@ -2997,7 +2997,24 @@ BOOL CMusicPlayerDlg::OnCommand(WPARAM wParam, LPARAM lParam)
                 {
                     if (item.playlist_info != nullptr)
                     {
-                        CPlayer::GetInstance().SetPlaylist(item.playlist_info->path, item.playlist_info->track, item.playlist_info->position, false, false);
+                        int track{ item.playlist_info->track };
+                        int position{ item.playlist_info->position };
+                        bool continue_play{ false };
+                        // 实现切换到播放列表时的同曲目继续播放
+                        if (theApp.m_play_setting_data.continue_when_switch_playlist)
+                        {
+                            SongInfo Last = CPlayer::GetInstance().GetCurrentSongInfo();
+                            CPlaylistFile playlist;
+                            playlist.LoadFromFile(item.playlist_info->path);
+                            int tmp = playlist.GetFileIndexInPlaylist(Last);
+                            if (tmp != -1)
+                            {
+                                track = tmp;
+                                position = CPlayer::GetInstance().GetCurrentPosition();
+                                continue_play = CPlayer::GetInstance().IsPlaying();
+                            }
+                        }
+                        CPlayer::GetInstance().SetPlaylist(item.playlist_info->path, track, position, false, continue_play);
                         UpdatePlayPauseButton();
                         DrawInfo(true);
                         CPlayer::GetInstance().SaveRecentPath();

--- a/MusicPlayer2/Player.cpp
+++ b/MusicPlayer2/Player.cpp
@@ -124,7 +124,7 @@ void CPlayer::IniPlayList(bool playlist_mode, bool refresh_info, bool play)
         }
         //m_index = 0;
         //m_song_num = m_playlist.size();
-        m_index_tmp = m_index;		//保存歌曲序号
+        m_index_tmp = m_index;		//保存歌曲序号，cue未解析情况下当前的m_index有可能超过当前歌曲数目，临时存储待cue解析后恢复
         if (m_index < 0 || m_index >= GetSongNum()) m_index = 0;		//确保当前歌曲序号不会超过歌曲总数
 
         //m_song_length = { 0, 0, 0 };
@@ -229,16 +229,16 @@ void CPlayer::IniPlaylistComplate()
     //m_song_num = m_playlist.size();
     m_index = m_index_tmp;
     CAudioCommon::GetCueTracks(m_playlist, m_pCore, m_index_tmp);
-    // 如果是播放列表模式则m_index_tmp可能在cue解析后变化，需更新(文件夹模式下m_index_tmp会得到错误结果)
+    // 如果是播放列表模式则m_index_tmp可能在cue解析后变化，需重新更新(文件夹模式下m_index_tmp会被处理为错误结果)
     if (m_playlist_mode)
         m_index = m_index_tmp;
 
     if (m_index < 0 || m_index >= GetSongNum()) m_index = 0;		//确保当前歌曲序号不会超过歌曲总数
     //统计列表总时长
     m_total_time = 0;
-    for (const auto& somg : m_playlist)
+    for (const auto& song : m_playlist)
     {
-        m_total_time += somg.lengh.toInt();
+        m_total_time += song.lengh.toInt();
     }
 
     //检查列表中的曲目是否在“我喜欢”播放列表中
@@ -289,6 +289,29 @@ void CPlayer::IniPlaylistComplate()
                     }
                 }
                 m_current_file_name_tmp.clear();
+                MusicControl(Command::OPEN);
+                MusicControl(Command::SEEK);
+                if (m_thread_info.play)
+                    MusicControl(Command::PLAY);
+            }
+            else if (!m_current_song_tmp.IsEmpty())     // 切换到文件夹模式时m_current_song_tmp不为空则查找播放此歌曲，同时定位到m_current_song_position_tmp
+            {
+                //重新载入播放列表后，查找正在播放项目的序号
+                MusicControl(Command::CLOSE);
+                if (sorted || m_thread_info.find_current_track)
+                {
+                    for (int i{}; i < GetSongNum(); i++)
+                    {
+                        if (m_current_song_tmp.IsSameSong(m_playlist[i]))
+                        {
+                            m_index = i;
+                            break;
+                        }
+                    }
+                }
+                m_current_position.fromInt(m_current_song_position_tmp);
+                m_current_song_tmp = SongInfo();
+                m_current_song_position_tmp = 0;
                 MusicControl(Command::OPEN);
                 MusicControl(Command::SEEK);
                 if (m_thread_info.play)
@@ -856,7 +879,7 @@ void CPlayer::ChangePath(const wstring& path, int track, bool play)
     m_index = track;
     //初始化播放列表
     IniPlayList(false, false, play);		//根据新路径重新初始化播放列表
-    m_current_position = { 0,0,0 };
+    m_current_position = { 0, 0, 0 };
     SaveConfig();
     SetTitle();
     //MusicControl(Command::OPEN);
@@ -872,12 +895,43 @@ void CPlayer::SetPath(const PathInfo& path_info)
         EmplaceCurrentPlaylistToRecent();
     else
         EmplaceCurrentPathToRecent();
+
+    // 实现切换到文件夹模式时的同曲目播放保持
+    // 由于文件夹模式无法预先得知当前歌曲在新文件夹中的track所以目前只想到更改文件夹时不改变当前播放
+    bool play{ false };
+    if (theApp.m_play_setting_data.continue_when_switch_playlist)
+    {
+        SongInfo now_song{ GetCurrentSongInfo() };
+        CFilePathHelper now_song_path{ now_song.file_path };
+        now_song_path.SetFilePath(now_song_path.GetDir());
+        bool contain_sub_folder{ path_info.contain_sub_folder || COSUPlayerHelper::IsOsuFolder(path_info.path) };
+        // 判断当前播放歌曲是否在目标路径下
+        do
+        {
+            if (now_song_path.GetFilePath() == path_info.path)
+            {
+                // 当前播放歌曲在将要切换到的路径中
+                // 记录播放信息，在void CPlayer::IniPlaylistComplate()中进行恢复
+                // m_current_song_tmp优先级高，存在时覆盖下面的track参数
+                m_current_song_position_tmp = GetCurrentPosition();
+                m_current_song_tmp = now_song;
+                play = (m_playing == PlayingState::PS_PLAYING);
+                break;
+            }
+            else if (now_song_path.GetFilePath().empty())
+            {
+                break;
+            }
+            now_song_path.SetFilePath(now_song_path.GetParentDir());
+        } while (contain_sub_folder);
+    }
+
     m_sort_mode = path_info.sort_mode;
     m_descending = path_info.descending;
     m_contain_sub_folder = path_info.contain_sub_folder;
-    ChangePath(path_info.path, path_info.track);
+    ChangePath(path_info.path, path_info.track, play);
     m_current_position.fromInt(path_info.position);
-    //MusicControl(Command::SEEK);
+    // MusicControl(Command::SEEK);
     EmplaceCurrentPathToRecent();		//保存新的路径到最近路径
 
 }

--- a/MusicPlayer2/Player.cpp
+++ b/MusicPlayer2/Player.cpp
@@ -845,7 +845,7 @@ void CPlayer::LoopPlaylist(int& song_track)
     }
 }
 
-void CPlayer::ChangePath(const wstring& path, int track, bool play)
+void CPlayer::ChangePath(const wstring& path, int track, int position, bool play)
 {
     if (m_loading) return;
     MusicControl(Command::CLOSE);
@@ -856,7 +856,7 @@ void CPlayer::ChangePath(const wstring& path, int track, bool play)
     m_index = track;
     //初始化播放列表
     IniPlayList(false, false, play);		//根据新路径重新初始化播放列表
-    m_current_position = { 0, 0, 0 };
+    m_current_position.fromInt(position);
     SaveConfig();
     SetTitle();
     //MusicControl(Command::OPEN);
@@ -875,8 +875,7 @@ void CPlayer::SetPath(const PathInfo& path_info)
     m_sort_mode = path_info.sort_mode;
     m_descending = path_info.descending;
     m_contain_sub_folder = path_info.contain_sub_folder;
-    ChangePath(path_info.path, path_info.track);
-    m_current_position.fromInt(path_info.position);
+    ChangePath(path_info.path, path_info.track, path_info.position);
     //MusicControl(Command::SEEK);
     EmplaceCurrentPathToRecent();		//保存新的路径到最近路径
 
@@ -953,8 +952,7 @@ void CPlayer::OpenFolder(wstring path, bool contain_sub_folder, bool play)
     }
     if (path_exist)			//如果打开的路径已经存在于最近路径中
     {
-        ChangePath(path, track, play);
-        m_current_position.fromInt(position);
+        ChangePath(path, track, position, play);
         MusicControl(Command::SEEK);
         EmplaceCurrentPathToRecent();		//保存打开的路径到最近路径
         SaveRecentPath();
@@ -963,7 +961,7 @@ void CPlayer::OpenFolder(wstring path, bool contain_sub_folder, bool play)
     {
         m_sort_mode = SM_FILE;
         m_descending = false;
-        ChangePath(path, 0, play);
+        ChangePath(path, 0, 0, play);
         EmplaceCurrentPathToRecent();		//保存新的路径到最近路径
         SaveRecentPath();
     }

--- a/MusicPlayer2/Player.cpp
+++ b/MusicPlayer2/Player.cpp
@@ -845,7 +845,7 @@ void CPlayer::LoopPlaylist(int& song_track)
     }
 }
 
-void CPlayer::ChangePath(const wstring& path, int track, int position, bool play)
+void CPlayer::ChangePath(const wstring& path, int track, bool play)
 {
     if (m_loading) return;
     MusicControl(Command::CLOSE);
@@ -856,7 +856,7 @@ void CPlayer::ChangePath(const wstring& path, int track, int position, bool play
     m_index = track;
     //初始化播放列表
     IniPlayList(false, false, play);		//根据新路径重新初始化播放列表
-    m_current_position.fromInt(position);
+    m_current_position = { 0,0,0 };
     SaveConfig();
     SetTitle();
     //MusicControl(Command::OPEN);
@@ -875,7 +875,8 @@ void CPlayer::SetPath(const PathInfo& path_info)
     m_sort_mode = path_info.sort_mode;
     m_descending = path_info.descending;
     m_contain_sub_folder = path_info.contain_sub_folder;
-    ChangePath(path_info.path, path_info.track, path_info.position);
+    ChangePath(path_info.path, path_info.track);
+    m_current_position.fromInt(path_info.position);
     //MusicControl(Command::SEEK);
     EmplaceCurrentPathToRecent();		//保存新的路径到最近路径
 
@@ -952,7 +953,8 @@ void CPlayer::OpenFolder(wstring path, bool contain_sub_folder, bool play)
     }
     if (path_exist)			//如果打开的路径已经存在于最近路径中
     {
-        ChangePath(path, track, position, play);
+        ChangePath(path, track, play);
+        m_current_position.fromInt(position);
         MusicControl(Command::SEEK);
         EmplaceCurrentPathToRecent();		//保存打开的路径到最近路径
         SaveRecentPath();
@@ -961,7 +963,7 @@ void CPlayer::OpenFolder(wstring path, bool contain_sub_folder, bool play)
     {
         m_sort_mode = SM_FILE;
         m_descending = false;
-        ChangePath(path, 0, 0, play);
+        ChangePath(path, 0, play);
         EmplaceCurrentPathToRecent();		//保存新的路径到最近路径
         SaveRecentPath();
     }

--- a/MusicPlayer2/Player.h
+++ b/MusicPlayer2/Player.h
@@ -86,6 +86,8 @@ private:
     wstring m_path;		            //文件夹模式下，当前播放文件的目录
     wstring m_playlist_path;        //当前播放列表文件的路径
     wstring m_current_file_name_tmp;	//打开单个音频时用于临时储存文件名
+    SongInfo m_current_song_tmp;        // 切换文件夹模式时临时存储歌曲信息以保持播放
+    int m_current_song_position_tmp;    // 切换文件夹模式时临时存储歌曲进度以保持播放
     wstring m_current_file_type;
     deque<PathInfo> m_recent_path;		//最近打开过的路径
 

--- a/MusicPlayer2/Player.h
+++ b/MusicPlayer2/Player.h
@@ -168,7 +168,7 @@ private:
     void IniPlayList(bool playlist_mode = false, bool refresh_info = false, bool play = false);	//初始化播放列表(如果参数playlist_mode为true，则为播放列表模式，否则从指定目录下搜索文件；
                                                                         //如果refresh_info为true，则不管theApp.m_song_data里是否有当前歌曲的信息，都从文件重新获取信息)
 
-    void ChangePath(const wstring& path, int track = 0, int position = 0, bool play = false);		//改变当前路径
+    void ChangePath(const wstring& path, int track = 0, bool play = false);		//改变当前路径
 
     void ApplyEqualizer(int channel, int gain);		//应用一个均衡器通道的增益
 

--- a/MusicPlayer2/Player.h
+++ b/MusicPlayer2/Player.h
@@ -168,7 +168,7 @@ private:
     void IniPlayList(bool playlist_mode = false, bool refresh_info = false, bool play = false);	//初始化播放列表(如果参数playlist_mode为true，则为播放列表模式，否则从指定目录下搜索文件；
                                                                         //如果refresh_info为true，则不管theApp.m_song_data里是否有当前歌曲的信息，都从文件重新获取信息)
 
-    void ChangePath(const wstring& path, int track = 0, bool play = false);		//改变当前路径
+    void ChangePath(const wstring& path, int track = 0, int position = 0, bool play = false);		//改变当前路径
 
     void ApplyEqualizer(int channel, int gain);		//应用一个均衡器通道的增益
 


### PR DESCRIPTION
切换到文件夹模式时的继续播放没想到怎么做
文件夹模式没有像`void CPlaylistFile::LoadFromFile(const wstring & file_path)`一样的快速加载方法
是个带有大量解析的过程，有可能很长，可能会影响体验