### PR TITLE
修复无法识别本地同名歌词文件的问题

### DIFF
--- a/MusicPlayer2/MusicPlayerCmdHelper.cpp
+++ b/MusicPlayer2/MusicPlayerCmdHelper.cpp
@@ -351,7 +351,7 @@ std::wstring CMusicPlayerCmdHelper::SearchLyricFile(const SongInfo& song, bool f
     // cue与osu文件禁止按音频文件名搜索，无视模糊搜索，优先搜索“艺术家 - 标题”
     bool find_org_name{ !song.is_cue && !COSUPlayerHelper::IsOsuFile(song.file_path) };
     CFilePathHelper lyric_path{ song.file_path };
-    if (find_org_name)
+    if (!find_org_name)
     {
         wstring ar_ti{ song.artist + L" - " + song.title + L".lrc"};    // 预先加扩展名防止之后ReplaceFileExtension替换误伤
         CCommon::FileNameNormalize(ar_ti);


### PR DESCRIPTION
修没修 #513 我不清楚，反正肯定是修了 #515 。注释与代码实际逻辑恰好相反导致了这一问题。