### PR TITLE
更新CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-# Controls when the action will run. 
+# Controls when the action will run.
 # Events list: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on: [push, pull_request, workflow_dispatch]
 jobs:
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check Out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.3
       # 所有版本链接：https://docs.microsoft.com/en-us/visualstudio/releases/2022/release-history
       #- name: 下载 vs_enterprise.exe
       #  run: Invoke-WebRequest "https://aka.ms/vs/17/release/vs_enterprise.exe" -OutFile vs_enterprise.exe
@@ -24,32 +24,30 @@ jobs:
       #    "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC", `
       #    "--add", "Microsoft.VisualStudio.Component.VC.14.29.16.11.MFC"
       - name: 设置 msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1.3.1
       - name: 编译
         run: msbuild -t:Build '-p:Configuration=Release;platform=x64' -m:4
-      - name: 打包可执行文件
-        run: |
-          cd x64/Release
-          7z a -mx9 '../../MusicPlayer2.x64.7z' '*.exe' '*.dll'
+      - name: 上传文件
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: MusicPlayer2.x64
+          path: |
+            ./x64/Release/*.exe
+            ./x64/Release/*.dll
       - name: 打包其他文件
         run: |
           cd x64/Release
           7z a -mx9 '../../MusicPlayer2.x64.other.7z' '-x!*.exe' '-x!*.dll' './*'
-      - name: 上传文件
-        uses: actions/upload-artifact@v2
-        with:
-          name: MusicPlayer2.x64
-          path: MusicPlayer2.x64.7z
-      - name: 上传文件
-        uses: actions/upload-artifact@v2
+      - name: 上传其他文件
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: MusicPlayer2.x64.other
-          path: MusicPlayer2.x64.other.7z
+          path: ./MusicPlayer2.x64.other.7z
   build-x86:
     runs-on: windows-latest
     steps:
       - name: Check Out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.3
       # 所有版本链接：https://docs.microsoft.com/en-us/visualstudio/releases/2022/release-history
       #- name: 下载 vs_enterprise.exe
       #  run: Invoke-WebRequest "https://aka.ms/vs/17/release/vs_enterprise.exe" -OutFile vs_enterprise.exe
@@ -66,24 +64,22 @@ jobs:
       #    "--add", "Microsoft.VisualStudio.Component.VC.ATLMFC", `
       #    "--add", "Microsoft.VisualStudio.Component.VC.14.29.16.11.MFC"
       - name: 设置 msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1.3.1
       - name: 编译
         run: msbuild -t:Build '-p:Configuration=Release;platform=x86' -m:4
-      - name: 打包可执行文件
-        run: |
-          cd Release
-          7z a -mx9 '../MusicPlayer2.x86.7z' '*.exe' '*.dll'
+      - name: 上传文件
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: MusicPlayer2.x86
+          path: |
+            ./Release/*.exe
+            ./Release/*.dll
       - name: 打包其他文件
         run: |
           cd Release
-          7z a -mx9 '../MusicPlayer2.x86.other.7z' '-x!*.exe' '-x!*.dll' './*'
-      - name: 上传文件
-        uses: actions/upload-artifact@v2
-        with:
-          name: MusicPlayer2.x86
-          path: MusicPlayer2.x86.7z
-      - name: 上传文件
-        uses: actions/upload-artifact@v2
+          7z a -mx9 './../MusicPlayer2.x86.other.7z' '-x!*.exe' '-x!*.dll' './*'
+      - name: 上传其他文件
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: MusicPlayer2.x86.other
-          path: MusicPlayer2.x86.other.7z
+          path: ./MusicPlayer2.x86.other.7z


### PR DESCRIPTION
更新Actions版本去掉警告
去掉可执行文件双层压缩
pdb有些大，感觉占用500MB的免费额度太多，故保持原样
如果需要的话可以上传时用排除模式选择文件
```yml
      - name: 上传其他文件
        uses: actions/upload-artifact@v3.1.2
        with:
          name: MusicPlayer2.x86.other
          path: |
            ./Release/*
            !./Release/*.exe
            !./Release/*.dll
```