### PR TITLE
全屏时禁用屏保，退出全屏恢复屏保

### DIFF
--- a/MusicPlayer2/CMainDialogBase.cpp
+++ b/MusicPlayer2/CMainDialogBase.cpp
@@ -40,10 +40,12 @@ void CMainDialogBase::SetFullScreen(bool full_screen)
 		struWndpl.showCmd = SW_SHOWNORMAL;
 		struWndpl.rcNormalPosition = monitor - offset;
 		SetWindowPlacement(&struWndpl);//该函数设置指定窗口的显示状态和显示大小位置等，是我们该程序最为重要的函数
+		SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED);//禁用屏保
 	}
 	else
 	{
 		SetWindowPlacement(&m_struOldWndpl);
+		SetThreadExecutionState(ES_CONTINUOUS);//开启屏保
 	}
 }
 


### PR DESCRIPTION
加两行代码，实现这个功能 [【功能请求】全屏时禁用屏保](https://github.com/zhongyang219/MusicPlayer2/issues/862)

做得更完善的话，应该把“全屏播放禁用屏保”（"Disable screen saver during playback" = True）这个功能塞到配置里，Settings 里面可以勾一下，不过要改的地方就多了，懒，先直接设置吧。
