### PR TITLE
修复移除窗口边框后激活窗口时标题栏区域出现闪烁的问题

### DIFF
--- a/MusicPlayer2/MusicPlayerDlg.cpp
+++ b/MusicPlayer2/MusicPlayerDlg.cpp
@@ -342,6 +342,7 @@ BEGIN_MESSAGE_MAP(CMusicPlayerDlg, CMainDialogBase)
     ON_COMMAND(ID_MORE_RECENT_ITEMS, &CMusicPlayerDlg::OnMoreRecentItems)
     ON_WM_NCCALCSIZE()
     ON_MESSAGE(WM_CLEAR_UI_SERCH_BOX, &CMusicPlayerDlg::OnClearUiSerchBox)
+    ON_WM_NCACTIVATE()
 END_MESSAGE_MAP()
 
 
@@ -6684,4 +6685,15 @@ afx_msg LRESULT CMusicPlayerDlg::OnClearUiSerchBox(WPARAM wParam, LPARAM lParam)
     }
 
     return 0;
+}
+
+BOOL CMusicPlayerDlg::OnNcActivate(BOOL bActive)
+{
+    if (theApp.m_app_setting_data.remove_titlebar_top_frame && CWinVersionHelper::IsWindows10OrLater() && !theApp.m_app_setting_data.show_window_frame && !IsZoomed() && !theApp.m_ui_data.full_screen) 
+    {
+        // 阻止默认窗口过程绘制非客户区边框
+        return CMainDialogBase::DefWindowProc(WM_NCACTIVATE, (WPARAM)bActive, (LPARAM)-1);
+    }
+
+    return CMainDialogBase::OnNcActivate(bActive);
 }

--- a/MusicPlayer2/MusicPlayerDlg.h
+++ b/MusicPlayer2/MusicPlayerDlg.h
@@ -553,4 +553,6 @@ public:
     afx_msg void OnNcCalcSize(BOOL bCalcValidRects, NCCALCSIZE_PARAMS* lpncsp);
 protected:
     afx_msg LRESULT OnClearUiSerchBox(WPARAM wParam, LPARAM lParam);
+public:
+    afx_msg BOOL OnNcActivate(BOOL bActive);
 };


### PR DESCRIPTION
修复wiki说明中移除窗口边框后激活窗口出现“白条”的问题：
处理`WM_NCACTIVATE`消息，移除边框后`lParam`传入`-1`至默认窗口过程阻止其绘制非客户区。

> lParam
> If this parameter is set to -1, [DefWindowProc](https://learn.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-defwindowproca) does not repaint the nonclient area to reflect the state change.